### PR TITLE
feat: プロファイル設定による実装切り替え機能の実装 (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,96 @@
+# Kairos - 勤怠管理システム
+
+Kairosは、Spring Bootで構築された勤怠管理システムです。勤怠表の管理、位置情報の追跡、勤務ルールの設定などの機能を提供します。
+
+## 技術スタック
+
+- Java 21
+- Spring Boot 3.5.3
+- PostgreSQL 42.7.3
+- Spring Security (JWT認証)
+- Maven
+
+## プロファイル設定
+
+本システムは、Spring Profilesを使用して開発環境と本番環境で異なるリポジトリ実装を切り替えることができます。
+
+### 開発環境（dev profile）
+
+開発環境では、データベース接続不要のInMemory実装を使用します。高速な開発とテストが可能です。
+
+```bash
+# 開発環境での起動（デフォルト）
+mvn spring-boot:run
+
+# または明示的にdevプロファイルを指定
+mvn spring-boot:run -Dspring-boot.run.arguments="--spring.profiles.active=dev"
+
+# 環境変数で指定
+export SPRING_PROFILES_ACTIVE=dev
+mvn spring-boot:run
+```
+
+### 本番環境（prod profile）
+
+本番環境では、PostgreSQLを使用したJPA実装で永続化を行います。
+
+```bash
+# 本番環境での起動
+mvn spring-boot:run -Dspring-boot.run.arguments="--spring.profiles.active=prod"
+
+# 環境変数で指定
+export SPRING_PROFILES_ACTIVE=prod
+mvn spring-boot:run
+
+# JARファイルでの実行
+java -jar target/kairos-0.1.0.jar --spring.profiles.active=prod
+```
+
+### プロファイル別の特徴
+
+| 設定項目 | 開発環境（dev） | 本番環境（prod） |
+|---------|----------------|-----------------|
+| リポジトリ実装 | InMemory | JPA (PostgreSQL) |
+| データ永続化 | なし（メモリ内のみ） | あり |
+| データベース接続 | 不要 | 必要 |
+| 起動速度 | 高速 | 通常 |
+| 用途 | 開発・テスト | 本番運用 |
+
+### デフォルトプロファイル
+
+プロファイルが指定されていない場合、`dev`プロファイルがデフォルトで使用されます。これは`application.yml`で設定されています。
+
+## プロファイル別設定ファイル
+
+- `src/main/resources/application.yml` - 共通設定とデフォルトプロファイル設定
+- `src/main/resources/application-dev.yml` - 開発環境専用設定
+- `src/main/resources/application-prod.yml` - 本番環境専用設定
+- `src/test/resources/application-test.yml` - テスト環境専用設定
+
+## Docker環境
+
+本番環境でPostgreSQLを使用する場合は、同梱のdocker-compose.ymlを使用してデータベースを起動できます：
+
+```bash
+cd kairos-backend
+docker-compose up -d
+```
+
+## ビルドとテスト
+
+```bash
+# プロジェクトのビルド
+mvn clean package
+
+# テストの実行（開発プロファイルで実行）
+mvn test
+
+# 特定のプロファイルでテスト
+mvn test -Dspring.profiles.active=dev
+```
+
+## 注意事項
+
+- 開発環境（InMemory実装）ではアプリケーション再起動時にデータが消失します
+- 本番環境ではPostgreSQLが起動している必要があります
+- 環境変数`SPRING_PROFILES_ACTIVE`はコマンドライン引数より優先度が低いです

--- a/kairos-backend/src/main/java/com/github/okanikani/kairos/locations/others/repositories/InMemoryLocationRepository.java
+++ b/kairos-backend/src/main/java/com/github/okanikani/kairos/locations/others/repositories/InMemoryLocationRepository.java
@@ -3,6 +3,7 @@ package com.github.okanikani.kairos.locations.others.repositories;
 import com.github.okanikani.kairos.locations.domains.models.entities.Location;
 import com.github.okanikani.kairos.locations.domains.models.repositories.LocationRepository;
 import com.github.okanikani.kairos.locations.domains.models.vos.User;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -17,6 +18,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * TODO: PostgreSQL等を使用した永続化実装への置き換え
  */
 @Repository
+@Profile("dev")
 public class InMemoryLocationRepository implements LocationRepository {
     
     private final Map<Long, Location> locations = new ConcurrentHashMap<>();

--- a/kairos-backend/src/main/java/com/github/okanikani/kairos/locations/others/repositories/JpaLocationRepository.java
+++ b/kairos-backend/src/main/java/com/github/okanikani/kairos/locations/others/repositories/JpaLocationRepository.java
@@ -5,7 +5,7 @@ import com.github.okanikani.kairos.locations.domains.models.repositories.Locatio
 import com.github.okanikani.kairos.locations.domains.models.vos.User;
 import com.github.okanikani.kairos.locations.others.jpa.entities.LocationJpaEntity;
 import com.github.okanikani.kairos.locations.others.jpa.repositories.LocationJpaRepository;
-import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
  * 業務要件: ドメインモデルとJPAエンティティ間の変換とデータ永続化を担当
  */
 @Repository
-@Primary
+@Profile("prod")
 public class JpaLocationRepository implements LocationRepository {
 
     private final LocationJpaRepository locationJpaRepository;

--- a/kairos-backend/src/main/java/com/github/okanikani/kairos/reportcreationrules/others/repositories/InMemoryReportCreationRuleRepository.java
+++ b/kairos-backend/src/main/java/com/github/okanikani/kairos/reportcreationrules/others/repositories/InMemoryReportCreationRuleRepository.java
@@ -3,6 +3,7 @@ package com.github.okanikani.kairos.reportcreationrules.others.repositories;
 import com.github.okanikani.kairos.reportcreationrules.domains.models.entities.ReportCreationRule;
 import com.github.okanikani.kairos.reportcreationrules.domains.models.repositories.ReportCreationRuleRepository;
 import com.github.okanikani.kairos.reportcreationrules.domains.models.vos.User;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -16,6 +17,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * TODO: PostgreSQL等を使用した永続化実装への置き換え
  */
 @Repository
+@Profile("dev")
 public class InMemoryReportCreationRuleRepository implements ReportCreationRuleRepository {
     
     private final Map<Long, ReportCreationRule> reportCreationRules = new ConcurrentHashMap<>();

--- a/kairos-backend/src/main/java/com/github/okanikani/kairos/reportcreationrules/others/repositories/JpaReportCreationRuleRepository.java
+++ b/kairos-backend/src/main/java/com/github/okanikani/kairos/reportcreationrules/others/repositories/JpaReportCreationRuleRepository.java
@@ -5,7 +5,7 @@ import com.github.okanikani.kairos.reportcreationrules.domains.models.repositori
 import com.github.okanikani.kairos.reportcreationrules.domains.models.vos.User;
 import com.github.okanikani.kairos.reportcreationrules.others.jpa.entities.ReportCreationRuleJpaEntity;
 import com.github.okanikani.kairos.reportcreationrules.others.jpa.repositories.ReportCreationRuleJpaRepository;
-import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
  * 業務要件: ドメインモデルとJPAエンティティ間の変換とデータ永続化を担当
  */
 @Repository
-@Primary
+@Profile("prod")
 public class JpaReportCreationRuleRepository implements ReportCreationRuleRepository {
 
     private final ReportCreationRuleJpaRepository reportCreationRuleJpaRepository;

--- a/kairos-backend/src/main/java/com/github/okanikani/kairos/reports/others/repositories/InMemoryReportRepository.java
+++ b/kairos-backend/src/main/java/com/github/okanikani/kairos/reports/others/repositories/InMemoryReportRepository.java
@@ -4,6 +4,7 @@ import com.github.okanikani.kairos.commons.exceptions.ResourceNotFoundException;
 import com.github.okanikani.kairos.reports.domains.models.entities.Report;
 import com.github.okanikani.kairos.reports.domains.models.repositories.ReportRepository;
 import com.github.okanikani.kairos.reports.domains.models.vos.User;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 import java.time.YearMonth;
@@ -20,6 +21,7 @@ import java.util.Objects;
  * TODO: PostgreSQL等を使用した永続化実装への置き換え
  */
 @Repository
+@Profile("dev")
 public class InMemoryReportRepository implements ReportRepository {
     
     private final Map<String, Report> storage = new HashMap<>();

--- a/kairos-backend/src/main/java/com/github/okanikani/kairos/reports/others/repositories/JpaReportRepository.java
+++ b/kairos-backend/src/main/java/com/github/okanikani/kairos/reports/others/repositories/JpaReportRepository.java
@@ -6,7 +6,7 @@ import com.github.okanikani.kairos.reports.domains.models.repositories.ReportRep
 import com.github.okanikani.kairos.reports.domains.models.vos.*;
 import com.github.okanikani.kairos.reports.others.jpa.entities.*;
 import com.github.okanikani.kairos.reports.others.jpa.repositories.ReportJpaRepository;
-import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 import java.time.YearMonth;
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
  * 業務要件: ドメインモデルとJPAエンティティ間の変換とデータ永続化を担当
  */
 @Repository
-@Primary
+@Profile("prod")
 public class JpaReportRepository implements ReportRepository {
 
     private final ReportJpaRepository reportJpaRepository;

--- a/kairos-backend/src/main/java/com/github/okanikani/kairos/rules/others/repositories/InMemoryDefaultWorkRuleRepository.java
+++ b/kairos-backend/src/main/java/com/github/okanikani/kairos/rules/others/repositories/InMemoryDefaultWorkRuleRepository.java
@@ -3,6 +3,7 @@ package com.github.okanikani.kairos.rules.others.repositories;
 import com.github.okanikani.kairos.rules.domains.models.entities.DefaultWorkRule;
 import com.github.okanikani.kairos.rules.domains.models.repositories.DefaultWorkRuleRepository;
 import com.github.okanikani.kairos.rules.domains.models.vos.User;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -16,6 +17,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * TODO: PostgreSQL等を使用した永続化実装への置き換え
  */
 @Repository
+@Profile("dev")
 public class InMemoryDefaultWorkRuleRepository implements DefaultWorkRuleRepository {
     
     private final Map<Long, DefaultWorkRule> defaultWorkRules = new ConcurrentHashMap<>();

--- a/kairos-backend/src/main/java/com/github/okanikani/kairos/rules/others/repositories/InMemoryWorkRuleRepository.java
+++ b/kairos-backend/src/main/java/com/github/okanikani/kairos/rules/others/repositories/InMemoryWorkRuleRepository.java
@@ -3,6 +3,7 @@ package com.github.okanikani.kairos.rules.others.repositories;
 import com.github.okanikani.kairos.rules.domains.models.entities.WorkRule;
 import com.github.okanikani.kairos.rules.domains.models.repositories.WorkRuleRepository;
 import com.github.okanikani.kairos.rules.domains.models.vos.User;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -18,6 +19,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * TODO: PostgreSQL等を使用した永続化実装への置き換え
  */
 @Repository
+@Profile("dev")
 public class InMemoryWorkRuleRepository implements WorkRuleRepository {
     
     private final Map<Long, WorkRule> workRules = new ConcurrentHashMap<>();

--- a/kairos-backend/src/main/java/com/github/okanikani/kairos/rules/others/repositories/JpaDefaultWorkRuleRepository.java
+++ b/kairos-backend/src/main/java/com/github/okanikani/kairos/rules/others/repositories/JpaDefaultWorkRuleRepository.java
@@ -5,7 +5,7 @@ import com.github.okanikani.kairos.rules.domains.models.repositories.DefaultWork
 import com.github.okanikani.kairos.rules.domains.models.vos.User;
 import com.github.okanikani.kairos.rules.others.jpa.entities.DefaultWorkRuleJpaEntity;
 import com.github.okanikani.kairos.rules.others.jpa.repositories.DefaultWorkRuleJpaRepository;
-import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
  * 業務要件: ドメインモデルとJPAエンティティ間の変換とデータ永続化を担当
  */
 @Repository
-@Primary
+@Profile("prod")
 public class JpaDefaultWorkRuleRepository implements DefaultWorkRuleRepository {
 
     private final DefaultWorkRuleJpaRepository defaultWorkRuleJpaRepository;

--- a/kairos-backend/src/main/java/com/github/okanikani/kairos/rules/others/repositories/JpaWorkRuleRepository.java
+++ b/kairos-backend/src/main/java/com/github/okanikani/kairos/rules/others/repositories/JpaWorkRuleRepository.java
@@ -5,7 +5,7 @@ import com.github.okanikani.kairos.rules.domains.models.repositories.WorkRuleRep
 import com.github.okanikani.kairos.rules.domains.models.vos.User;
 import com.github.okanikani.kairos.rules.others.jpa.entities.WorkRuleJpaEntity;
 import com.github.okanikani.kairos.rules.others.jpa.repositories.WorkRuleJpaRepository;
-import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
  * 業務要件: ドメインモデルとJPAエンティティ間の変換とデータ永続化を担当
  */
 @Repository
-@Primary
+@Profile("prod")
 public class JpaWorkRuleRepository implements WorkRuleRepository {
 
     private final WorkRuleJpaRepository workRuleJpaRepository;

--- a/kairos-backend/src/main/resources/application-dev.yml
+++ b/kairos-backend/src/main/resources/application-dev.yml
@@ -1,0 +1,29 @@
+# 開発環境設定
+spring:
+  # 開発環境ではInMemory実装を使用するため、データソース関連の自動設定を除外
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+      - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+      - org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration
+
+# JWT設定（開発環境用）
+jwt:
+  secret: devSecretKeyForJWTGenerationThisIsOnlyForDevelopment
+  expiration: 86400000  # 24時間
+
+# サーバー設定（開発環境）
+server:
+  error:
+    include-message: always
+    include-binding-errors: always
+    include-stacktrace: always  # 開発環境ではスタックトレース表示
+
+# ログ設定（開発環境）
+logging:
+  level:
+    root: INFO
+    com.github.okanikani.kairos: DEBUG
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+    org.springframework.web: DEBUG  # 開発環境ではWebログも詳細表示

--- a/kairos-backend/src/main/resources/application-prod.yml
+++ b/kairos-backend/src/main/resources/application-prod.yml
@@ -1,0 +1,52 @@
+# 本番環境設定
+spring:
+  # 本番環境ではPostgreSQLを使用
+  datasource:
+    url: ${DATABASE_URL:jdbc:postgresql://localhost:5432/kairos_db}
+    username: ${DATABASE_USERNAME:kairos_user}
+    password: ${DATABASE_PASSWORD:kairos_password}
+    driver-class-name: org.postgresql.Driver
+    
+    # HikariCP設定（本番環境用）
+    hikari:
+      connection-timeout: 30000
+      maximum-pool-size: 10
+      minimum-idle: 5
+      idle-timeout: 600000
+      max-lifetime: 1800000
+  
+  # JPA/Hibernate設定（本番環境）
+  jpa:
+    hibernate:
+      ddl-auto: validate  # 本番環境では検証のみ（破壊的な変更を防ぐ）
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: false  # 本番環境ではフォーマットなし
+        default_schema: public
+        jdbc:
+          batch_size: 25  # パフォーマンス向上のためバッチ処理
+        order_inserts: true
+        order_updates: true
+    show-sql: false  # 本番環境ではSQL非表示
+    open-in-view: false
+
+# JWT設定（本番環境用）
+jwt:
+  secret: ${JWT_SECRET:changeMeInProductionWithSecureRandomKey}
+  expiration: ${JWT_EXPIRATION:86400000}  # デフォルト24時間
+
+# サーバー設定（本番環境）
+server:
+  error:
+    include-message: never  # 本番環境ではエラーメッセージを隠蔽
+    include-binding-errors: never
+    include-stacktrace: never  # 本番環境ではスタックトレース非表示
+
+# ログ設定（本番環境）
+logging:
+  level:
+    root: WARN
+    com.github.okanikani.kairos: INFO
+    org.hibernate.SQL: WARN
+    org.springframework: WARN

--- a/kairos-backend/src/main/resources/application.yml
+++ b/kairos-backend/src/main/resources/application.yml
@@ -3,6 +3,10 @@ spring:
   application:
     name: kairos
   
+  # デフォルトプロファイル設定（指定がない場合は開発環境）
+  profiles:
+    active: dev
+  
   # データソース設定
   datasource:
     url: jdbc:postgresql://localhost:5432/kairos_db

--- a/kairos-backend/src/test/resources/application-test.yml
+++ b/kairos-backend/src/test/resources/application-test.yml
@@ -1,0 +1,23 @@
+# テスト環境設定
+spring:
+  # テスト環境ではInMemory実装を使用
+  profiles:
+    active: dev
+  
+  # 自動設定の除外（InMemory実装使用時にデータソース関連の自動設定を除外）
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+      - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+      - org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration
+
+# JWT設定（テスト用）
+jwt:
+  secret: testSecretKeyForJWTGenerationThisIsOnlyForTesting
+  expiration: 3600000  # 1時間（テスト用短縮）
+
+# ログ設定（テスト環境）
+logging:
+  level:
+    root: WARN
+    com.github.okanikani.kairos: DEBUG


### PR DESCRIPTION
- Spring Profilesを使用してInMemoryとJPA実装を切り替え可能に
- 開発環境(dev)ではInMemory実装、本番環境(prod)ではJPA実装を使用
- application-dev.yml、application-prod.yml、application-test.ymlを追加
- 全リポジトリクラスに@Profile アノテーションを追加
- デフォルトプロファイルをdevに設定
- プロファイル切り替え方法をREADME.mdに記載

Closes #1

🤖 Generated with [Claude Code](https://claude.ai/code)