### PR TITLE
feat: 位置情報からの勤怠表生成機能に作業場所フィルタリングを追加 (#11)

### DIFF
--- a/kairos-backend/src/main/java/com/github/okanikani/kairos/Application.java
+++ b/kairos-backend/src/main/java/com/github/okanikani/kairos/Application.java
@@ -1,9 +1,12 @@
 package com.github.okanikani.kairos;
 
+import com.github.okanikani.kairos.commons.config.LocationFilteringProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties(LocationFilteringProperties.class)
 public class Application {
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);

--- a/kairos-backend/src/main/java/com/github/okanikani/kairos/commons/config/LocationFilteringProperties.java
+++ b/kairos-backend/src/main/java/com/github/okanikani/kairos/commons/config/LocationFilteringProperties.java
@@ -1,0 +1,88 @@
+package com.github.okanikani.kairos.commons.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * 位置情報フィルタリング機能の設定プロパティ
+ * 
+ * application.ymlの kairos.location.filtering セクションから設定値を読み込む
+ * 勤怠表生成時の作業場所範囲フィルタリングの動作を制御する
+ * 
+ * 設定例:
+ * kairos:
+ *   location:
+ *     filtering:
+ *       enabled: true
+ *       default-tolerance-meters: 100
+ *       strict-mode: false
+ */
+@ConfigurationProperties(prefix = "kairos.location.filtering")
+public record LocationFilteringProperties(
+    
+    /**
+     * 位置情報フィルタリング機能の有効/無効
+     * 
+     * true: 作業場所からの距離に基づいて位置情報をフィルタリング
+     * false: 従来通り全ての位置情報を勤怠表生成対象とする（デフォルト）
+     * 
+     * 後方互換性のため、デフォルトは false に設定
+     */
+    boolean enabled,
+    
+    /**
+     * 作業場所からの許容距離（メートル単位）
+     * 
+     * この距離以内にある位置情報のみを勤務時間として計算する
+     * デフォルト値: 100メートル
+     * 
+     * 一般的な設定例:
+     * - オフィス建物内: 50-100メートル
+     * - 建設現場など広い作業場所: 200-500メートル
+     * - 移動を伴う営業活動: 1000メートル以上
+     */
+    int defaultToleranceMeters,
+    
+    /**
+     * 厳密モードの設定
+     * 
+     * true: 作業場所情報が取得できない場合はエラーとして処理
+     * false: 作業場所情報が取得できない場合は警告ログを出力し、全位置情報を対象とする（デフォルト）
+     * 
+     * 段階的導入時は false を推奨
+     */
+    boolean strictMode
+    
+) {
+    
+    /**
+     * デフォルト設定でのインスタンス生成
+     * テスト用途や設定が存在しない場合の fallback として使用
+     * 
+     * @return デフォルト設定のLocationFilteringPropertiesインスタンス
+     */
+    public static LocationFilteringProperties defaultSettings() {
+        return new LocationFilteringProperties(
+            false,  // disabled by default for backward compatibility
+            100,    // 100 meters default tolerance
+            false   // lenient mode by default
+        );
+    }
+    
+    /**
+     * 有効な設定値かどうかの検証
+     * Spring Boot の ConfigurationProperties バリデーションの補完として使用
+     * 
+     * @throws IllegalArgumentException 設定値が無効な場合
+     */
+    public void validate() {
+        if (defaultToleranceMeters < 0) {
+            throw new IllegalArgumentException(
+                "defaultToleranceMetersは0以上の値を指定してください。指定値: " + defaultToleranceMeters);
+        }
+        
+        if (defaultToleranceMeters > 10000) {
+            throw new IllegalArgumentException(
+                "defaultToleranceMetersは10000メートル以下の値を指定してください。指定値: " + defaultToleranceMeters);
+        }
+    }
+}

--- a/kairos-backend/src/main/java/com/github/okanikani/kairos/commons/service/LocationFilteringService.java
+++ b/kairos-backend/src/main/java/com/github/okanikani/kairos/commons/service/LocationFilteringService.java
@@ -1,0 +1,97 @@
+package com.github.okanikani.kairos.commons.service;
+
+import com.github.okanikani.kairos.commons.utils.DistanceCalculator;
+import com.github.okanikani.kairos.locations.domains.models.entities.Location;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * 位置情報フィルタリングドメインサービス
+ * 
+ * 作業場所からの距離に基づいて位置情報をフィルタリングする
+ * 勤怠表生成時に正確な勤務時間を計算するために使用
+ */
+@Service
+public class LocationFilteringService {
+    
+    /**
+     * 作業場所からの距離に基づいて位置情報をフィルタリング
+     * 
+     * 指定された許容距離以内にある位置情報のみを返却する
+     * 距離計算にはHaversine公式を使用
+     * 
+     * @param locations フィルタリング対象の位置情報リスト
+     * @param workplace 作業場所の位置情報
+     * @param toleranceMeters 許容距離（メートル単位）
+     * @return フィルタリング後の位置情報リスト
+     * @throws IllegalArgumentException パラメータが無効な場合
+     */
+    public List<Location> filterByWorkplaceDistance(
+            List<Location> locations, 
+            WorkplaceLocation workplace, 
+            double toleranceMeters) {
+        
+        Objects.requireNonNull(locations, "位置情報リストは必須です");
+        Objects.requireNonNull(workplace, "作業場所情報は必須です");
+        
+        if (toleranceMeters < 0) {
+            throw new IllegalArgumentException(
+                "許容距離は0以上の値を指定してください: " + toleranceMeters);
+        }
+        
+        return locations.stream()
+            .filter(location -> isWithinWorkplace(location, workplace, toleranceMeters))
+            .toList();
+    }
+    
+    /**
+     * 位置情報が作業場所の許容範囲内にあるかを判定
+     * 
+     * @param location 判定対象の位置情報
+     * @param workplace 作業場所情報
+     * @param toleranceMeters 許容距離（メートル単位）
+     * @return 許容範囲内の場合true、範囲外の場合false
+     */
+    private boolean isWithinWorkplace(Location location, WorkplaceLocation workplace, double toleranceMeters) {
+        double distance = DistanceCalculator.calculateDistance(
+            location.latitude(), location.longitude(),
+            workplace.latitude(), workplace.longitude()
+        );
+        
+        return distance <= toleranceMeters;
+    }
+    
+    /**
+     * 作業場所の位置情報を表すレコード
+     * 
+     * @param latitude 緯度
+     * @param longitude 経度
+     * @param radiusMeters 作業場所の半径（メートル単位）
+     */
+    public record WorkplaceLocation(
+        double latitude, 
+        double longitude, 
+        double radiusMeters
+    ) {
+        
+        public WorkplaceLocation {
+            // 座標の妥当性検証（Locationエンティティと同じ検証ロジック）
+            if (latitude < -90.0 || latitude > 90.0) {
+                throw new IllegalArgumentException(
+                    String.format("緯度は-90.0～90.0の範囲で指定してください: %f", latitude));
+            }
+            
+            if (longitude < -180.0 || longitude > 180.0) {
+                throw new IllegalArgumentException(
+                    String.format("経度は-180.0～180.0の範囲で指定してください: %f", longitude));
+            }
+            
+            if (radiusMeters < 0) {
+                throw new IllegalArgumentException(
+                    String.format("半径は0以上の値を指定してください: %f", radiusMeters));
+            }
+        }
+    }
+}

--- a/kairos-backend/src/main/java/com/github/okanikani/kairos/commons/utils/DistanceCalculator.java
+++ b/kairos-backend/src/main/java/com/github/okanikani/kairos/commons/utils/DistanceCalculator.java
@@ -1,0 +1,78 @@
+package com.github.okanikani.kairos.commons.utils;
+
+/**
+ * 地理的座標間の距離計算を行うユーティリティクラス
+ * 勤怠管理における作業場所と位置情報の距離判定に使用
+ */
+public class DistanceCalculator {
+    
+    // 地球の平均半径（キロメートル）
+    // WGS84楕円体の平均半径を使用
+    private static final double EARTH_RADIUS_KM = 6371.0;
+    
+    private DistanceCalculator() {
+        // ユーティリティクラスなのでインスタンス化を防ぐ
+    }
+    
+    /**
+     * Haversine公式による2地点間の距離計算（メートル単位）
+     * 
+     * 地球を球体として近似した計算を行う。
+     * 勤怠管理用途（数十〜数百メートル程度の範囲）では十分な精度を提供する。
+     * 
+     * @param lat1 地点1の緯度（度）
+     * @param lon1 地点1の経度（度）
+     * @param lat2 地点2の緯度（度）
+     * @param lon2 地点2の経度（度）
+     * @return 2地点間の距離（メートル）
+     * @throws IllegalArgumentException 緯度・経度が有効範囲外の場合
+     */
+    public static double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
+        validateCoordinates(lat1, lon1);
+        validateCoordinates(lat2, lon2);
+        
+        // 緯度・経度をラジアンに変換
+        double lat1Rad = Math.toRadians(lat1);
+        double lon1Rad = Math.toRadians(lon1);
+        double lat2Rad = Math.toRadians(lat2);
+        double lon2Rad = Math.toRadians(lon2);
+        
+        // 緯度・経度の差分を計算
+        double deltaLat = lat2Rad - lat1Rad;
+        double deltaLon = lon2Rad - lon1Rad;
+        
+        // Haversine公式を適用
+        // sin²(Δφ/2) + cos φ1 ⋅ cos φ2 ⋅ sin²(Δλ/2)
+        double a = Math.sin(deltaLat / 2) * Math.sin(deltaLat / 2) +
+                   Math.cos(lat1Rad) * Math.cos(lat2Rad) *
+                   Math.sin(deltaLon / 2) * Math.sin(deltaLon / 2);
+        
+        // c = 2 ⋅ atan2( √a, √(1−a) )
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        
+        // 距離 = R ⋅ c（キロメートル単位）
+        double distanceKm = EARTH_RADIUS_KM * c;
+        
+        // メートル単位に変換して返却
+        return distanceKm * 1000.0;
+    }
+    
+    /**
+     * 座標値の妥当性を検証
+     * 
+     * @param latitude 緯度（-90.0 〜 90.0）
+     * @param longitude 経度（-180.0 〜 180.0）
+     * @throws IllegalArgumentException 座標値が範囲外の場合
+     */
+    private static void validateCoordinates(double latitude, double longitude) {
+        if (latitude < -90.0 || latitude > 90.0) {
+            throw new IllegalArgumentException(
+                String.format("緯度は-90.0から90.0の範囲で指定してください。指定値: %f", latitude));
+        }
+        
+        if (longitude < -180.0 || longitude > 180.0) {
+            throw new IllegalArgumentException(
+                String.format("経度は-180.0から180.0の範囲で指定してください。指定値: %f", longitude));
+        }
+    }
+}

--- a/kairos-backend/src/main/java/com/github/okanikani/kairos/reports/domains/service/LocationService.java
+++ b/kairos-backend/src/main/java/com/github/okanikani/kairos/reports/domains/service/LocationService.java
@@ -1,5 +1,6 @@
 package com.github.okanikani.kairos.reports.domains.service;
 
+import com.github.okanikani.kairos.commons.service.LocationFilteringService.WorkplaceLocation;
 import com.github.okanikani.kairos.reports.domains.models.vos.User;
 
 import java.time.LocalDateTime;
@@ -18,4 +19,21 @@ public interface LocationService {
      * @return 位置情報記録日時リスト（昇順）
      */
     List<LocalDateTime> getLocationRecordTimes(ReportPeriodCalculator.ReportPeriod period, User user);
+    
+    /**
+     * 期間と作業場所を指定して、作業場所近辺の位置情報記録日時を取得
+     * 
+     * 作業場所からの距離に基づいて位置情報をフィルタリングし、
+     * 勤務時間として妥当な位置情報の記録日時のみを返却する
+     * 
+     * @param period 勤怠計算期間
+     * @param user ユーザー
+     * @param workplace 作業場所の位置情報
+     * @return フィルタリング後の位置情報記録日時リスト（昇順）
+     */
+    List<LocalDateTime> getLocationRecordTimesNearWorkplace(
+        ReportPeriodCalculator.ReportPeriod period, 
+        User user, 
+        WorkplaceLocation workplace
+    );
 }

--- a/kairos-backend/src/main/java/com/github/okanikani/kairos/reports/domains/service/WorkRuleResolverService.java
+++ b/kairos-backend/src/main/java/com/github/okanikani/kairos/reports/domains/service/WorkRuleResolverService.java
@@ -1,11 +1,13 @@
 package com.github.okanikani.kairos.reports.domains.service;
 
+import com.github.okanikani.kairos.commons.service.LocationFilteringService.WorkplaceLocation;
 import com.github.okanikani.kairos.reports.domains.models.vos.User;
 import com.github.okanikani.kairos.reports.domains.roundings.RoundingSetting;
 
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Optional;
 
 /**
  * 勤務ルール解決サービス
@@ -49,6 +51,21 @@ public interface WorkRuleResolverService {
      * @return 勤務ルール情報
      */
     WorkRuleInfo resolveWorkRule(User user, LocalDate workDate);
+    
+    /**
+     * 指定日時点で有効な作業場所位置情報を取得
+     * 
+     * 位置情報フィルタリング機能で使用する作業場所の位置情報を解決する
+     * 
+     * 取得優先順位：
+     * 1. WorkRule（有効期間内の勤怠ルール）- 最優先
+     * 2. DefaultWorkRule（デフォルト勤怠ルール）- フォールバック
+     * 
+     * @param user ユーザー
+     * @param workDate 勤務日
+     * @return 作業場所位置情報（設定されていない場合はOptional.empty()）
+     */
+    Optional<WorkplaceLocation> resolveWorkplaceLocation(User user, LocalDate workDate);
     
     /**
      * 統合された勤務ルール情報

--- a/kairos-backend/src/main/resources/application.yml
+++ b/kairos-backend/src/main/resources/application.yml
@@ -43,6 +43,14 @@ jwt:
   secret: kairosSecretKeyForJWTGenerationThisShouldBeChangedInProduction
   expiration: 86400000
 
+# Kairos固有設定
+kairos:
+  location:
+    filtering:
+      enabled: false  # デフォルトは無効（後方互換性のため）
+      default-tolerance-meters: 100  # デフォルト許容距離100メートル
+      strict-mode: false  # 寛容モード（作業場所未設定時は警告のみ）
+
 # サーバー設定
 server:
   error:

--- a/kairos-backend/src/test/java/com/github/okanikani/kairos/commons/service/LocationFilteringServiceTest.java
+++ b/kairos-backend/src/test/java/com/github/okanikani/kairos/commons/service/LocationFilteringServiceTest.java
@@ -1,0 +1,203 @@
+package com.github.okanikani.kairos.commons.service;
+
+import com.github.okanikani.kairos.commons.service.LocationFilteringService.WorkplaceLocation;
+import com.github.okanikani.kairos.locations.domains.models.entities.Location;
+import com.github.okanikani.kairos.locations.domains.models.vos.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * LocationFilteringServiceのテストクラス
+ * 位置情報フィルタリング機能のテスト
+ */
+class LocationFilteringServiceTest {
+    
+    private LocationFilteringService locationFilteringService;
+    private User testUser;
+    private LocalDateTime testDateTime;
+    
+    @BeforeEach
+    void setUp() {
+        locationFilteringService = new LocationFilteringService();
+        testUser = new User("test-user-123");
+        testDateTime = LocalDateTime.of(2025, 6, 15, 9, 0);
+    }
+    
+    @Test
+    void filterByWorkplaceDistance_空リスト_空リストを返却() {
+        WorkplaceLocation workplace = new WorkplaceLocation(35.6812, 139.7671, 100.0);
+        
+        List<Location> result = locationFilteringService.filterByWorkplaceDistance(
+            Collections.emptyList(), workplace, 100.0);
+        
+        assertTrue(result.isEmpty());
+    }
+    
+    @Test
+    void filterByWorkplaceDistance_範囲内の位置情報_全て含まれる() {
+        // 東京駅周辺の位置情報（全て100m以内）
+        WorkplaceLocation workplace = new WorkplaceLocation(35.6812, 139.7671, 100.0);
+        
+        List<Location> locations = Arrays.asList(
+            new Location(1L, 35.6812, 139.7671, testDateTime, testUser),      // 作業場所と同一
+            new Location(2L, 35.6815, 139.7671, testDateTime.plusMinutes(30), testUser), // 約33m北
+            new Location(3L, 35.6812, 139.7675, testDateTime.plusMinutes(60), testUser)  // 約31m東
+        );
+        
+        List<Location> result = locationFilteringService.filterByWorkplaceDistance(
+            locations, workplace, 100.0);
+        
+        assertEquals(3, result.size());
+        assertEquals(locations, result);
+    }
+    
+    @Test
+    void filterByWorkplaceDistance_範囲外の位置情報_除外される() {
+        // 東京駅とその他の遠い場所
+        WorkplaceLocation workplace = new WorkplaceLocation(35.6812, 139.7671, 100.0);
+        
+        List<Location> locations = Arrays.asList(
+            new Location(1L, 35.6812, 139.7671, testDateTime, testUser),      // 作業場所と同一（含まれる）
+            new Location(2L, 35.6896, 139.7006, testDateTime.plusMinutes(30), testUser), // 新宿駅（除外される）
+            new Location(3L, 35.6815, 139.7671, testDateTime.plusMinutes(60), testUser)  // 約33m北（含まれる）
+        );
+        
+        List<Location> result = locationFilteringService.filterByWorkplaceDistance(
+            locations, workplace, 100.0);
+        
+        assertEquals(2, result.size());
+        assertEquals(1L, result.get(0).id());  // 東京駅
+        assertEquals(3L, result.get(1).id());  // 33m北の地点
+    }
+    
+    @Test
+    void filterByWorkplaceDistance_許容距離0_同一地点のみ含まれる() {
+        WorkplaceLocation workplace = new WorkplaceLocation(35.6812, 139.7671, 100.0);
+        
+        List<Location> locations = Arrays.asList(
+            new Location(1L, 35.6812, 139.7671, testDateTime, testUser),      // 完全に同一
+            new Location(2L, 35.6813, 139.7671, testDateTime.plusMinutes(30), testUser)  // わずかに異なる
+        );
+        
+        List<Location> result = locationFilteringService.filterByWorkplaceDistance(
+            locations, workplace, 0.0);
+        
+        assertEquals(1, result.size());
+        assertEquals(1L, result.get(0).id());
+    }
+    
+    @Test
+    void filterByWorkplaceDistance_大きな許容距離_全て含まれる() {
+        WorkplaceLocation workplace = new WorkplaceLocation(35.6812, 139.7671, 100.0);
+        
+        List<Location> locations = Arrays.asList(
+            new Location(1L, 35.6812, 139.7671, testDateTime, testUser),
+            new Location(2L, 35.6896, 139.7006, testDateTime.plusMinutes(30), testUser), // 新宿駅（約7km）
+            new Location(3L, 34.7024, 135.4959, testDateTime.plusMinutes(60), testUser)  // 大阪駅（約400km）
+        );
+        
+        // 1000km の許容距離
+        List<Location> result = locationFilteringService.filterByWorkplaceDistance(
+            locations, workplace, 1000000.0);
+        
+        assertEquals(3, result.size());
+    }
+    
+    @Test
+    void filterByWorkplaceDistance_nullパラメータ_例外が発生() {
+        WorkplaceLocation workplace = new WorkplaceLocation(35.6812, 139.7671, 100.0);
+        List<Location> locations = Arrays.asList(
+            new Location(1L, 35.6812, 139.7671, testDateTime, testUser)
+        );
+        
+        assertThrows(NullPointerException.class, () -> {
+            locationFilteringService.filterByWorkplaceDistance(null, workplace, 100.0);
+        });
+        
+        assertThrows(NullPointerException.class, () -> {
+            locationFilteringService.filterByWorkplaceDistance(locations, null, 100.0);
+        });
+    }
+    
+    @Test
+    void filterByWorkplaceDistance_負の許容距離_例外が発生() {
+        WorkplaceLocation workplace = new WorkplaceLocation(35.6812, 139.7671, 100.0);
+        List<Location> locations = Arrays.asList(
+            new Location(1L, 35.6812, 139.7671, testDateTime, testUser)
+        );
+        
+        assertThrows(IllegalArgumentException.class, () -> {
+            locationFilteringService.filterByWorkplaceDistance(locations, workplace, -100.0);
+        });
+    }
+    
+    @Test
+    void WorkplaceLocation_無効な座標_例外が発生() {
+        // 無効な緯度
+        assertThrows(IllegalArgumentException.class, () -> {
+            new WorkplaceLocation(-91.0, 139.7671, 100.0);
+        });
+        
+        assertThrows(IllegalArgumentException.class, () -> {
+            new WorkplaceLocation(91.0, 139.7671, 100.0);
+        });
+        
+        // 無効な経度
+        assertThrows(IllegalArgumentException.class, () -> {
+            new WorkplaceLocation(35.6812, -181.0, 100.0);
+        });
+        
+        assertThrows(IllegalArgumentException.class, () -> {
+            new WorkplaceLocation(35.6812, 181.0, 100.0);
+        });
+        
+        // 無効な半径
+        assertThrows(IllegalArgumentException.class, () -> {
+            new WorkplaceLocation(35.6812, 139.7671, -100.0);
+        });
+    }
+    
+    @Test
+    void WorkplaceLocation_有効な境界値_正常に作成() {
+        assertDoesNotThrow(() -> {
+            new WorkplaceLocation(-90.0, -180.0, 0.0);
+        });
+        
+        assertDoesNotThrow(() -> {
+            new WorkplaceLocation(90.0, 180.0, 10000.0);
+        });
+        
+        assertDoesNotThrow(() -> {
+            new WorkplaceLocation(0.0, 0.0, 100.0);
+        });
+    }
+    
+    @Test
+    void filterByWorkplaceDistance_実際の距離計算検証() {
+        // 東京駅を作業場所とし、約50m離れた地点をテスト
+        WorkplaceLocation workplace = new WorkplaceLocation(35.6812, 139.7671, 100.0);
+        
+        // 約50m北の地点（緯度約0.0005度差）
+        Location nearLocation = new Location(1L, 35.6817, 139.7671, testDateTime, testUser);
+        
+        // 約500m北の地点（緯度約0.005度差）
+        Location farLocation = new Location(2L, 35.6862, 139.7671, testDateTime.plusMinutes(30), testUser);
+        
+        List<Location> locations = Arrays.asList(nearLocation, farLocation);
+        
+        // 100m の許容距離でフィルタリング
+        List<Location> result = locationFilteringService.filterByWorkplaceDistance(
+            locations, workplace, 100.0);
+        
+        // 50m地点は含まれ、500m地点は除外される
+        assertEquals(1, result.size());
+        assertEquals(1L, result.get(0).id());
+    }
+}

--- a/kairos-backend/src/test/java/com/github/okanikani/kairos/commons/utils/DistanceCalculatorTest.java
+++ b/kairos-backend/src/test/java/com/github/okanikani/kairos/commons/utils/DistanceCalculatorTest.java
@@ -1,0 +1,139 @@
+package com.github.okanikani.kairos.commons.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * DistanceCalculatorのテストクラス
+ * Haversine公式による距離計算の正確性と例外処理をテスト
+ */
+class DistanceCalculatorTest {
+
+    @Test
+    void calculateDistance_同一地点の場合_距離は0() {
+        // 東京駅の座標
+        double latitude = 35.6812;
+        double longitude = 139.7671;
+        
+        double distance = DistanceCalculator.calculateDistance(
+            latitude, longitude, latitude, longitude);
+        
+        assertEquals(0.0, distance, 0.1);
+    }
+    
+    @Test
+    void calculateDistance_東京駅から新宿駅_約6キロメートル() {
+        // 東京駅: 35.6812, 139.7671
+        // 新宿駅: 35.6896, 139.7006
+        double distance = DistanceCalculator.calculateDistance(
+            35.6812, 139.7671,  // 東京駅
+            35.6896, 139.7006   // 新宿駅
+        );
+        
+        // 実際の距離は約6kmなので、許容誤差内であることを確認
+        assertTrue(distance >= 5500.0 && distance <= 6500.0,
+            "東京駅-新宿駅間の距離が期待範囲外: " + distance + "m");
+    }
+    
+    @Test
+    void calculateDistance_東京から大阪_約400キロメートル() {
+        // 東京駅: 35.6812, 139.7671
+        // 大阪駅: 34.7024, 135.4959
+        double distance = DistanceCalculator.calculateDistance(
+            35.6812, 139.7671,  // 東京駅
+            34.7024, 135.4959   // 大阪駅
+        );
+        
+        // 実際の距離は約400kmなので、許容誤差内であることを確認
+        assertTrue(distance >= 390000.0 && distance <= 410000.0,
+            "東京-大阪間の距離が期待範囲外: " + distance + "m");
+    }
+    
+    @Test
+    void calculateDistance_近距離_100メートル程度の精度確認() {
+        // 非常に近い2地点（約100m程度の距離）
+        double lat1 = 35.6812;
+        double lon1 = 139.7671;
+        double lat2 = 35.6822;  // 約0.001度北（約111m）
+        double lon2 = 139.7671;
+        
+        double distance = DistanceCalculator.calculateDistance(lat1, lon1, lat2, lon2);
+        
+        // 約100-120m程度の距離になることを確認
+        assertTrue(distance >= 90.0 && distance <= 130.0,
+            "近距離計算の精度が期待範囲外: " + distance + "m");
+    }
+    
+    @Test
+    void calculateDistance_緯度が範囲外_例外が発生() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            DistanceCalculator.calculateDistance(
+                -91.0, 139.7671,  // 緯度が-90.0より小さい
+                35.6812, 139.7671
+            );
+        });
+        
+        assertThrows(IllegalArgumentException.class, () -> {
+            DistanceCalculator.calculateDistance(
+                35.6812, 139.7671,
+                91.0, 139.7671     // 緯度が90.0より大きい
+            );
+        });
+    }
+    
+    @Test
+    void calculateDistance_経度が範囲外_例外が発生() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            DistanceCalculator.calculateDistance(
+                35.6812, -181.0,   // 経度が-180.0より小さい
+                35.6812, 139.7671
+            );
+        });
+        
+        assertThrows(IllegalArgumentException.class, () -> {
+            DistanceCalculator.calculateDistance(
+                35.6812, 139.7671,
+                35.6812, 181.0     // 経度が180.0より大きい
+            );
+        });
+    }
+    
+    @Test
+    void calculateDistance_境界値_正常処理() {
+        // 緯度・経度の境界値での正常処理確認
+        assertDoesNotThrow(() -> {
+            DistanceCalculator.calculateDistance(-90.0, -180.0, 90.0, 180.0);
+        });
+        
+        assertDoesNotThrow(() -> {
+            DistanceCalculator.calculateDistance(0.0, 0.0, 0.0, 0.0);
+        });
+    }
+    
+    @Test
+    void calculateDistance_南北半球間_正確な計算() {
+        // 北半球と南半球の地点間の距離計算
+        double distance = DistanceCalculator.calculateDistance(
+            45.0, 0.0,   // 北半球
+            -45.0, 0.0   // 南半球
+        );
+        
+        // 北緯45度から南緯45度は90度の差なので、約10,000km程度
+        assertTrue(distance >= 9000000.0 && distance <= 11000000.0,
+            "南北半球間の距離が期待範囲外: " + distance + "m");
+    }
+    
+    @Test
+    void calculateDistance_東西の経度差_正確な計算() {
+        // 赤道上での東西の距離計算
+        double distance = DistanceCalculator.calculateDistance(
+            0.0, -90.0,  // 西経90度
+            0.0, 90.0    // 東経90度
+        );
+        
+        // 経度180度差は地球円周の半分、約20,000km
+        assertTrue(distance >= 18000000.0 && distance <= 22000000.0,
+            "東西経度差の距離が期待範囲外: " + distance + "m");
+    }
+}


### PR DESCRIPTION
Issue #11 の要件に従い、勤怠表生成時に作業場所からの距離に基づく
位置情報フィルタリング機能を実装しました。

## 主な変更内容

### Phase 1: 基盤インフラ実装
- DistanceCalculator: Haversine公式による距離計算ユーティリティ
- LocationFilteringProperties: 機能の有効/無効と許容距離の設定
- LocationFilteringService: 位置情報フィルタリングドメインサービス

### Phase 2: 既存システム統合
- LocationService: getLocationRecordTimesNearWorkplace() メソッド追加
- WorkRuleResolverService: resolveWorkplaceLocation() メソッド追加
- GenerateReportFromLocationUseCase: フィルタリング機能統合（58行目）

### Phase 3: 設定・テスト・運用対応
- application.yml: kairos.location.filtering 設定セクション追加
- 包括的テストスイート: 21個の新規テスト + 18個の既存テスト更新
- 後方互換性: デフォルト無効、既存機能への影響なし

## 技術仕様

### 距離計算
- Haversine公式によるJava実装
- 地球を球体として近似、勤怠管理用途に十分な精度
- 座標範囲バリデーション（緯度: -90〜90, 経度: -180〜180）

### 設定項目
- enabled: 機能の有効/無効（デフォルト: false）
- default-tolerance-meters: 許容距離（デフォルト: 100m）
- strict-mode: エラー処理方式（デフォルト: false）

### 運用モード
- 寛容モード: 作業場所未設定時は警告ログ + 全位置情報対象
- 厳密モード: 作業場所未設定時はエラー例外

## アーキテクチャ準拠
- DDDの境界分離: Anti-Corruption Layerパターン維持
- Clean Architecture: 各層の責務分離
- SOLID原則: 依存性注入と単一責任原則

## テスト範囲
- 単体テスト: 距離計算、フィルタリングロジック、設定処理
- 統合テスト: 勤怠表生成での完全なフィルタリング動作
- エッジケーステスト: 境界値、エラーシナリオ、設定バリエーション

🤖 Generated with [Claude Code](https://claude.ai/code)