### PR TITLE
feat: Issue #8 位置情報管理機能の追加実装完了

### DIFF
--- a/kairos-backend/src/main/java/com/github/okanikani/kairos/locations/applications/usecases/PageableSearchLocationsUseCase.java
+++ b/kairos-backend/src/main/java/com/github/okanikani/kairos/locations/applications/usecases/PageableSearchLocationsUseCase.java
@@ -1,0 +1,81 @@
+package com.github.okanikani.kairos.locations.applications.usecases;
+
+import com.github.okanikani.kairos.locations.applications.usecases.dto.LocationResponse;
+import com.github.okanikani.kairos.locations.applications.usecases.dto.PageableSearchLocationsRequest;
+import com.github.okanikani.kairos.locations.applications.usecases.dto.PagedLocationResponse;
+import com.github.okanikani.kairos.locations.domains.models.entities.Location;
+import com.github.okanikani.kairos.locations.domains.models.repositories.LocationRepository;
+import com.github.okanikani.kairos.locations.domains.models.vos.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * ページネーション対応位置情報期間検索ユースケース
+ */
+@Service
+public class PageableSearchLocationsUseCase {
+
+    private final LocationRepository locationRepository;
+
+    public PageableSearchLocationsUseCase(LocationRepository locationRepository) {
+        this.locationRepository = Objects.requireNonNull(locationRepository, "locationRepositoryは必須です");
+    }
+
+    /**
+     * 指定した期間のユーザーの位置情報をページネーション付きで検索する
+     * 
+     * @param request 検索リクエスト（開始・終了日時、ページング情報）
+     * @param userId ユーザーID
+     * @return ページネーション付き位置情報レスポンス
+     * @throws NullPointerException requestまたはuserIdがnullの場合
+     * @throws IllegalArgumentException 検索条件が不正な場合
+     */
+    public PagedLocationResponse execute(PageableSearchLocationsRequest request, String userId) {
+        Objects.requireNonNull(request, "requestは必須です");
+        Objects.requireNonNull(userId, "userIdは必須です");
+        
+        User user = new User(userId);
+        
+        // ページング情報を作成（記録日時の昇順でソート）
+        Pageable pageable = PageRequest.of(
+            request.page(),
+            request.size(),
+            Sort.by(Sort.Direction.ASC, "recordedAt")
+        );
+        
+        // ページネーション付きで位置情報を取得
+        Page<Location> locationPage = locationRepository.findByUserAndDateTimeRange(
+            user,
+            request.startDateTime(),
+            request.endDateTime(),
+            pageable
+        );
+        
+        // LocationResponseに変換
+        Page<LocationResponse> locationResponsePage = locationPage.map(this::toLocationResponse);
+        
+        // PagedLocationResponseに変換して返却
+        return PagedLocationResponse.from(locationResponsePage);
+    }
+
+    /**
+     * LocationエンティティをLocationResponseに変換する
+     * 
+     * @param location 位置情報エンティティ
+     * @return 位置情報レスポンス
+     */
+    private LocationResponse toLocationResponse(Location location) {
+        return new LocationResponse(
+            location.id(),
+            location.latitude(),
+            location.longitude(),
+            location.recordedAt()
+        );
+    }
+}

--- a/kairos-backend/src/main/java/com/github/okanikani/kairos/locations/applications/usecases/UpdateLocationUseCase.java
+++ b/kairos-backend/src/main/java/com/github/okanikani/kairos/locations/applications/usecases/UpdateLocationUseCase.java
@@ -1,0 +1,72 @@
+package com.github.okanikani.kairos.locations.applications.usecases;
+
+import com.github.okanikani.kairos.commons.exceptions.AuthorizationException;
+import com.github.okanikani.kairos.commons.exceptions.ResourceNotFoundException;
+import com.github.okanikani.kairos.commons.exceptions.ValidationException;
+import com.github.okanikani.kairos.locations.applications.usecases.dto.LocationResponse;
+import com.github.okanikani.kairos.locations.applications.usecases.dto.UpdateLocationRequest;
+import com.github.okanikani.kairos.locations.domains.models.entities.Location;
+import com.github.okanikani.kairos.locations.domains.models.repositories.LocationRepository;
+import com.github.okanikani.kairos.locations.domains.models.vos.User;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+
+/**
+ * 位置情報更新ユースケース
+ * 既存の位置情報の緯度、経度、記録日時を更新する
+ */
+@Service
+public class UpdateLocationUseCase {
+    
+    private final LocationRepository locationRepository;
+    
+    public UpdateLocationUseCase(LocationRepository locationRepository) {
+        this.locationRepository = Objects.requireNonNull(locationRepository, "locationRepositoryは必須です");
+    }
+    
+    /**
+     * 位置情報を更新する
+     * @param id 更新対象の位置情報ID
+     * @param request 更新内容
+     * @param userId 更新を実行するユーザーID
+     * @return 更新された位置情報
+     * @throws ValidationException 位置情報が存在しない、または他ユーザーの位置情報の場合
+     */
+    public LocationResponse execute(Long id, UpdateLocationRequest request, String userId) {
+        Objects.requireNonNull(id, "IDは必須です");
+        Objects.requireNonNull(request, "更新リクエストは必須です");
+        Objects.requireNonNull(userId, "ユーザーIDは必須です");
+        
+        // 既存の位置情報を取得
+        Location existingLocation = locationRepository.findById(id);
+        if (existingLocation == null) {
+            throw new ResourceNotFoundException("指定された位置情報が見つかりません");
+        }
+        
+        // 所有者チェック
+        if (!existingLocation.user().userId().equals(userId)) {
+            throw new AuthorizationException("他のユーザーの位置情報は更新できません");
+        }
+        
+        // 更新する位置情報を作成（IDとユーザーは変更不可）
+        Location updatedLocation = new Location(
+            existingLocation.id(),
+            request.latitude(),
+            request.longitude(),
+            request.recordedAt(),
+            existingLocation.user()
+        );
+        
+        // 保存
+        Location savedLocation = locationRepository.save(updatedLocation);
+        
+        // レスポンスに変換
+        return new LocationResponse(
+            savedLocation.id(),
+            savedLocation.latitude(),
+            savedLocation.longitude(),
+            savedLocation.recordedAt()
+        );
+    }
+}

--- a/kairos-backend/src/main/java/com/github/okanikani/kairos/locations/applications/usecases/dto/PageableSearchLocationsRequest.java
+++ b/kairos-backend/src/main/java/com/github/okanikani/kairos/locations/applications/usecases/dto/PageableSearchLocationsRequest.java
@@ -1,0 +1,48 @@
+package com.github.okanikani.kairos.locations.applications.usecases.dto;
+
+import com.github.okanikani.kairos.commons.exceptions.ValidationException;
+import java.time.LocalDateTime;
+
+/**
+ * ページネーション対応位置情報検索リクエスト
+ * 
+ * @param startDateTime 検索開始日時（この日時以降）
+ * @param endDateTime 検索終了日時（この日時以前）
+ * @param page ページ番号（0から開始）
+ * @param size 1ページあたりの件数
+ */
+public record PageableSearchLocationsRequest(
+    LocalDateTime startDateTime,
+    LocalDateTime endDateTime,
+    int page,
+    int size
+) {
+    /**
+     * バリデーション用コンストラクタ
+     */
+    public PageableSearchLocationsRequest {
+        // 必須パラメータのnullチェック
+        if (startDateTime == null) {
+            throw new NullPointerException("startDateTimeは必須です");
+        }
+        if (endDateTime == null) {
+            throw new NullPointerException("endDateTimeは必須です");
+        }
+        
+        // 開始日時が終了日時より後の場合はエラー
+        if (startDateTime.isAfter(endDateTime)) {
+            throw new ValidationException("開始日時は終了日時より前である必要があります");
+        }
+        
+        // ページネーションパラメータのバリデーション
+        if (page < 0) {
+            throw new ValidationException("ページ番号は0以上である必要があります");
+        }
+        if (size <= 0) {
+            throw new ValidationException("ページサイズは1以上である必要があります");
+        }
+        if (size > 100) {
+            throw new ValidationException("ページサイズは100以下である必要があります");
+        }
+    }
+}

--- a/kairos-backend/src/main/java/com/github/okanikani/kairos/locations/applications/usecases/dto/PagedLocationResponse.java
+++ b/kairos-backend/src/main/java/com/github/okanikani/kairos/locations/applications/usecases/dto/PagedLocationResponse.java
@@ -1,0 +1,45 @@
+package com.github.okanikani.kairos.locations.applications.usecases.dto;
+
+import java.util.List;
+
+/**
+ * ページネーション対応位置情報レスポンス
+ * 
+ * @param content 位置情報リスト
+ * @param page 現在のページ番号（0から開始）
+ * @param size 1ページあたりの件数
+ * @param totalElements 全件数
+ * @param totalPages 全ページ数
+ * @param first 最初のページかどうか
+ * @param last 最後のページかどうか
+ * @param hasNext 次のページが存在するかどうか
+ * @param hasPrevious 前のページが存在するかどうか
+ */
+public record PagedLocationResponse(
+    List<LocationResponse> content,
+    int page,
+    int size,
+    long totalElements,
+    int totalPages,
+    boolean first,
+    boolean last,
+    boolean hasNext,
+    boolean hasPrevious
+) {
+    /**
+     * Spring Data JPA の Page オブジェクトから PagedLocationResponse を作成するファクトリメソッド
+     */
+    public static PagedLocationResponse from(org.springframework.data.domain.Page<LocationResponse> page) {
+        return new PagedLocationResponse(
+            page.getContent(),
+            page.getNumber(),
+            page.getSize(),
+            page.getTotalElements(),
+            page.getTotalPages(),
+            page.isFirst(),
+            page.isLast(),
+            page.hasNext(),
+            page.hasPrevious()
+        );
+    }
+}

--- a/kairos-backend/src/main/java/com/github/okanikani/kairos/locations/applications/usecases/dto/UpdateLocationRequest.java
+++ b/kairos-backend/src/main/java/com/github/okanikani/kairos/locations/applications/usecases/dto/UpdateLocationRequest.java
@@ -1,0 +1,18 @@
+package com.github.okanikani.kairos.locations.applications.usecases.dto;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+/**
+ * 位置情報更新リクエスト
+ * 位置情報の緯度、経度、記録日時を更新する
+ */
+public record UpdateLocationRequest(
+    double latitude,          // 緯度（-90.0 ～ 90.0）
+    double longitude,         // 経度（-180.0 ～ 180.0）
+    LocalDateTime recordedAt  // 記録日時
+) {
+    public UpdateLocationRequest {
+        Objects.requireNonNull(recordedAt, "記録日時は必須です");
+    }
+}

--- a/kairos-backend/src/main/java/com/github/okanikani/kairos/locations/domains/models/repositories/LocationRepository.java
+++ b/kairos-backend/src/main/java/com/github/okanikani/kairos/locations/domains/models/repositories/LocationRepository.java
@@ -2,6 +2,8 @@ package com.github.okanikani.kairos.locations.domains.models.repositories;
 
 import com.github.okanikani.kairos.locations.domains.models.entities.Location;
 import com.github.okanikani.kairos.locations.domains.models.vos.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -66,4 +68,14 @@ public interface LocationRepository {
      * @param id 削除する位置情報のID
      */
     void deleteById(Long id);
+
+    /**
+     * 指定したユーザーの指定した日時範囲の位置情報をページネーション付きで取得する
+     * @param user 対象ユーザー
+     * @param startDateTime 開始日時
+     * @param endDateTime 終了日時
+     * @param pageable ページング情報（ページ番号、サイズ、ソート条件）
+     * @return 指定ユーザーの指定範囲の位置情報ページ
+     */
+    Page<Location> findByUserAndDateTimeRange(User user, LocalDateTime startDateTime, LocalDateTime endDateTime, Pageable pageable);
 }

--- a/kairos-backend/src/main/java/com/github/okanikani/kairos/locations/others/jpa/repositories/LocationJpaRepository.java
+++ b/kairos-backend/src/main/java/com/github/okanikani/kairos/locations/others/jpa/repositories/LocationJpaRepository.java
@@ -1,6 +1,8 @@
 package com.github.okanikani.kairos.locations.others.jpa.repositories;
 
 import com.github.okanikani.kairos.locations.others.jpa.entities.LocationJpaEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -38,6 +40,21 @@ public interface LocationJpaRepository extends JpaRepository<LocationJpaEntity, 
     List<LocationJpaEntity> findByUserIdAndRecordedAtBetween(@Param("userId") String userId,
                                                              @Param("startDateTime") LocalDateTime startDateTime,
                                                              @Param("endDateTime") LocalDateTime endDateTime);
+
+    /**
+     * ユーザーIDと期間で位置情報をページネーション付きで検索
+     * 
+     * @param userId ユーザーID
+     * @param startDateTime 開始日時
+     * @param endDateTime 終了日時
+     * @param pageable ページング情報
+     * @return 該当期間の位置情報ページ
+     */
+    @Query("SELECT l FROM LocationJpaEntity l WHERE l.userId = :userId AND l.recordedAt BETWEEN :startDateTime AND :endDateTime")
+    Page<LocationJpaEntity> findByUserIdAndRecordedAtBetween(@Param("userId") String userId,
+                                                             @Param("startDateTime") LocalDateTime startDateTime,
+                                                             @Param("endDateTime") LocalDateTime endDateTime,
+                                                             Pageable pageable);
 
     /**
      * ユーザーIDで記録日時のみを取得（勤怠表生成用）

--- a/kairos-backend/src/main/java/com/github/okanikani/kairos/locations/others/repositories/JpaLocationRepository.java
+++ b/kairos-backend/src/main/java/com/github/okanikani/kairos/locations/others/repositories/JpaLocationRepository.java
@@ -6,6 +6,8 @@ import com.github.okanikani.kairos.locations.domains.models.vos.User;
 import com.github.okanikani.kairos.locations.others.jpa.entities.LocationJpaEntity;
 import com.github.okanikani.kairos.locations.others.jpa.repositories.LocationJpaRepository;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -98,6 +100,18 @@ public class JpaLocationRepository implements LocationRepository {
         
         return locationJpaRepository.findRecordedAtByUserIdAndPeriod(
                 user.userId(), startDateTime, endDateTime);
+    }
+
+    @Override
+    public Page<Location> findByUserAndDateTimeRange(User user, LocalDateTime startDateTime, LocalDateTime endDateTime, Pageable pageable) {
+        Page<LocationJpaEntity> jpaEntityPage = locationJpaRepository.findByUserIdAndRecordedAtBetween(
+            user.userId(), 
+            startDateTime, 
+            endDateTime, 
+            pageable
+        );
+        
+        return jpaEntityPage.map(this::toDomainModel);
     }
 
     /**

--- a/kairos-backend/src/test/java/com/github/okanikani/kairos/locations/applications/usecases/PageableSearchLocationsUseCaseTest.java
+++ b/kairos-backend/src/test/java/com/github/okanikani/kairos/locations/applications/usecases/PageableSearchLocationsUseCaseTest.java
@@ -1,0 +1,276 @@
+package com.github.okanikani.kairos.locations.applications.usecases;
+
+import com.github.okanikani.kairos.commons.exceptions.ValidationException;
+import com.github.okanikani.kairos.locations.applications.usecases.dto.LocationResponse;
+import com.github.okanikani.kairos.locations.applications.usecases.dto.PageableSearchLocationsRequest;
+import com.github.okanikani.kairos.locations.applications.usecases.dto.PagedLocationResponse;
+import com.github.okanikani.kairos.locations.domains.models.entities.Location;
+import com.github.okanikani.kairos.locations.domains.models.repositories.LocationRepository;
+import com.github.okanikani.kairos.locations.domains.models.vos.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class PageableSearchLocationsUseCaseTest {
+
+    @Autowired
+    private PageableSearchLocationsUseCase pageableSearchLocationsUseCase;
+
+    @MockitoBean
+    private LocationRepository locationRepository;
+
+    private User testUser;
+    private LocalDateTime startDateTime;
+    private LocalDateTime endDateTime;
+
+    @BeforeEach
+    void setUp() {
+        testUser = new User("testuser");
+        startDateTime = LocalDateTime.of(2024, 1, 1, 9, 0, 0);
+        endDateTime = LocalDateTime.of(2024, 1, 1, 18, 0, 0);
+    }
+
+    @Test
+    void execute_正常ケース_ページネーション付きで位置情報が取得される() {
+        // Arrange
+        PageableSearchLocationsRequest request = new PageableSearchLocationsRequest(
+            startDateTime,
+            endDateTime,
+            0, // page
+            10 // size
+        );
+
+        List<Location> locationList = Arrays.asList(
+            new Location(1L, 35.6812, 139.7671, startDateTime.plusHours(1), testUser),
+            new Location(2L, 35.6813, 139.7672, startDateTime.plusHours(2), testUser),
+            new Location(3L, 35.6814, 139.7673, startDateTime.plusHours(3), testUser)
+        );
+
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Location> locationPage = new PageImpl<>(locationList, pageable, 3);
+
+        when(locationRepository.findByUserAndDateTimeRange(
+            eq(testUser),
+            eq(startDateTime),
+            eq(endDateTime),
+            any(Pageable.class)
+        )).thenReturn(locationPage);
+
+        // Act
+        PagedLocationResponse response = pageableSearchLocationsUseCase.execute(request, "testuser");
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(0, response.page());
+        assertEquals(10, response.size());
+        assertEquals(3, response.totalElements());
+        assertEquals(1, response.totalPages());
+        assertTrue(response.first());
+        assertTrue(response.last());
+        assertFalse(response.hasNext());
+        assertFalse(response.hasPrevious());
+
+        List<LocationResponse> content = response.content();
+        assertEquals(3, content.size());
+        assertEquals(1L, content.get(0).id());
+        assertEquals(35.6812, content.get(0).latitude());
+        assertEquals(139.7671, content.get(0).longitude());
+
+        verify(locationRepository).findByUserAndDateTimeRange(
+            eq(testUser),
+            eq(startDateTime),
+            eq(endDateTime),
+            any(Pageable.class)
+        );
+    }
+
+    @Test
+    void execute_第2ページの取得_正しいページング情報が設定される() {
+        // Arrange
+        PageableSearchLocationsRequest request = new PageableSearchLocationsRequest(
+            startDateTime,
+            endDateTime,
+            1, // page
+            2  // size
+        );
+
+        List<Location> locationList = Arrays.asList(
+            new Location(3L, 35.6814, 139.7673, startDateTime.plusHours(3), testUser),
+            new Location(4L, 35.6815, 139.7674, startDateTime.plusHours(4), testUser)
+        );
+
+        Pageable pageable = PageRequest.of(1, 2);
+        Page<Location> locationPage = new PageImpl<>(locationList, pageable, 5); // 全5件
+
+        when(locationRepository.findByUserAndDateTimeRange(
+            eq(testUser),
+            eq(startDateTime),
+            eq(endDateTime),
+            any(Pageable.class)
+        )).thenReturn(locationPage);
+
+        // Act
+        PagedLocationResponse response = pageableSearchLocationsUseCase.execute(request, "testuser");
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(1, response.page());
+        assertEquals(2, response.size());
+        assertEquals(5, response.totalElements());
+        assertEquals(3, response.totalPages()); // (5 + 2 - 1) / 2 = 3
+        assertFalse(response.first());
+        assertFalse(response.last());
+        assertTrue(response.hasNext());
+        assertTrue(response.hasPrevious());
+
+        assertEquals(2, response.content().size());
+    }
+
+    @Test
+    void execute_該当データなし_空のページが返される() {
+        // Arrange
+        PageableSearchLocationsRequest request = new PageableSearchLocationsRequest(
+            startDateTime,
+            endDateTime,
+            0,
+            10
+        );
+
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Location> emptyPage = new PageImpl<>(List.of(), pageable, 0);
+
+        when(locationRepository.findByUserAndDateTimeRange(
+            eq(testUser),
+            eq(startDateTime),
+            eq(endDateTime),
+            any(Pageable.class)
+        )).thenReturn(emptyPage);
+
+        // Act
+        PagedLocationResponse response = pageableSearchLocationsUseCase.execute(request, "testuser");
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(0, response.page());
+        assertEquals(10, response.size());
+        assertEquals(0, response.totalElements());
+        assertEquals(0, response.totalPages());
+        assertTrue(response.first());
+        assertTrue(response.last());
+        assertFalse(response.hasNext());
+        assertFalse(response.hasPrevious());
+        assertTrue(response.content().isEmpty());
+    }
+
+    @Test
+    void execute_リクエストがnull_例外が発生する() {
+        // Act & Assert
+        NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> pageableSearchLocationsUseCase.execute(null, "testuser")
+        );
+
+        assertEquals("requestは必須です", exception.getMessage());
+        verify(locationRepository, never()).findByUserAndDateTimeRange(any(), any(), any(), any());
+    }
+
+    @Test
+    void execute_ユーザーIDがnull_例外が発生する() {
+        // Arrange
+        PageableSearchLocationsRequest request = new PageableSearchLocationsRequest(
+            startDateTime,
+            endDateTime,
+            0,
+            10
+        );
+
+        // Act & Assert
+        NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> pageableSearchLocationsUseCase.execute(request, null)
+        );
+
+        assertEquals("userIdは必須です", exception.getMessage());
+        verify(locationRepository, never()).findByUserAndDateTimeRange(any(), any(), any(), any());
+    }
+
+    @Test
+    void execute_開始日時が終了日時より後_例外が発生する() {
+        // Act & Assert
+        ValidationException exception = assertThrows(
+            ValidationException.class,
+            () -> new PageableSearchLocationsRequest(
+                endDateTime,   // 終了日時
+                startDateTime, // 開始日時（逆転）
+                0,
+                10
+            )
+        );
+
+        assertEquals("開始日時は終了日時より前である必要があります", exception.getMessage());
+    }
+
+    @Test
+    void execute_無効なページ番号_例外が発生する() {
+        // Act & Assert
+        ValidationException exception = assertThrows(
+            ValidationException.class,
+            () -> new PageableSearchLocationsRequest(
+                startDateTime,
+                endDateTime,
+                -1, // 無効なページ番号
+                10
+            )
+        );
+
+        assertEquals("ページ番号は0以上である必要があります", exception.getMessage());
+    }
+
+    @Test
+    void execute_無効なページサイズ_例外が発生する() {
+        // Act & Assert
+        ValidationException exception = assertThrows(
+            ValidationException.class,
+            () -> new PageableSearchLocationsRequest(
+                startDateTime,
+                endDateTime,
+                0,
+                0 // 無効なページサイズ
+            )
+        );
+
+        assertEquals("ページサイズは1以上である必要があります", exception.getMessage());
+    }
+
+    @Test
+    void execute_ページサイズが上限超過_例外が発生する() {
+        // Act & Assert
+        ValidationException exception = assertThrows(
+            ValidationException.class,
+            () -> new PageableSearchLocationsRequest(
+                startDateTime,
+                endDateTime,
+                0,
+                101 // 上限を超過したページサイズ
+            )
+        );
+
+        assertEquals("ページサイズは100以下である必要があります", exception.getMessage());
+    }
+}

--- a/kairos-backend/src/test/java/com/github/okanikani/kairos/locations/applications/usecases/UpdateLocationUseCaseTest.java
+++ b/kairos-backend/src/test/java/com/github/okanikani/kairos/locations/applications/usecases/UpdateLocationUseCaseTest.java
@@ -1,0 +1,184 @@
+package com.github.okanikani.kairos.locations.applications.usecases;
+
+import com.github.okanikani.kairos.commons.exceptions.AuthorizationException;
+import com.github.okanikani.kairos.commons.exceptions.ResourceNotFoundException;
+import com.github.okanikani.kairos.commons.exceptions.ValidationException;
+import com.github.okanikani.kairos.locations.applications.usecases.dto.LocationResponse;
+import com.github.okanikani.kairos.locations.applications.usecases.dto.UpdateLocationRequest;
+import com.github.okanikani.kairos.locations.domains.models.entities.Location;
+import com.github.okanikani.kairos.locations.domains.models.repositories.LocationRepository;
+import com.github.okanikani.kairos.locations.domains.models.vos.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class UpdateLocationUseCaseTest {
+
+    @Autowired
+    private UpdateLocationUseCase updateLocationUseCase;
+
+    @MockitoBean
+    private LocationRepository locationRepository;
+
+    private User testUser;
+    private Location existingLocation;
+    private LocalDateTime now;
+
+    @BeforeEach
+    void setUp() {
+        testUser = new User("testuser");
+        now = LocalDateTime.now();
+        existingLocation = new Location(1L, 35.6762, 139.6503, now, testUser);
+    }
+
+    @Test
+    void execute_正常ケース_位置情報が更新される() {
+        // Arrange
+        UpdateLocationRequest request = new UpdateLocationRequest(
+            35.6892,  // 新しい緯度
+            139.6917, // 新しい経度
+            now.plusHours(1) // 新しい記録日時
+        );
+        
+        Location updatedLocation = new Location(
+            1L,
+            request.latitude(),
+            request.longitude(),
+            request.recordedAt(),
+            testUser
+        );
+        
+        when(locationRepository.findById(1L)).thenReturn(existingLocation);
+        when(locationRepository.save(any(Location.class))).thenReturn(updatedLocation);
+
+        // Act
+        LocationResponse response = updateLocationUseCase.execute(1L, request, "testuser");
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(1L, response.id());
+        assertEquals(35.6892, response.latitude());
+        assertEquals(139.6917, response.longitude());
+        assertEquals(now.plusHours(1), response.recordedAt());
+        
+        verify(locationRepository).findById(1L);
+        verify(locationRepository).save(any(Location.class));
+    }
+
+    @Test
+    void execute_位置情報が存在しない場合_例外が発生する() {
+        // Arrange
+        UpdateLocationRequest request = new UpdateLocationRequest(
+            35.6892,
+            139.6917,
+            now.plusHours(1)
+        );
+        
+        when(locationRepository.findById(999L)).thenReturn(null);
+
+        // Act & Assert
+        ResourceNotFoundException exception = assertThrows(
+            ResourceNotFoundException.class,
+            () -> updateLocationUseCase.execute(999L, request, "testuser")
+        );
+        
+        assertEquals("指定された位置情報が見つかりません", exception.getMessage());
+        verify(locationRepository).findById(999L);
+        verify(locationRepository, never()).save(any());
+    }
+
+    @Test
+    void execute_他ユーザーの位置情報を更新しようとした場合_例外が発生する() {
+        // Arrange
+        UpdateLocationRequest request = new UpdateLocationRequest(
+            35.6892,
+            139.6917,
+            now.plusHours(1)
+        );
+        
+        when(locationRepository.findById(1L)).thenReturn(existingLocation);
+
+        // Act & Assert
+        AuthorizationException exception = assertThrows(
+            AuthorizationException.class,
+            () -> updateLocationUseCase.execute(1L, request, "otheruser")
+        );
+        
+        assertEquals("他のユーザーの位置情報は更新できません", exception.getMessage());
+        verify(locationRepository).findById(1L);
+        verify(locationRepository, never()).save(any());
+    }
+
+    @Test
+    void execute_無効な緯度_例外が発生する() {
+        // Arrange
+        UpdateLocationRequest request = new UpdateLocationRequest(
+            91.0, // 無効な緯度
+            139.6917,
+            now.plusHours(1)
+        );
+        
+        when(locationRepository.findById(1L)).thenReturn(existingLocation);
+
+        // Act & Assert
+        ValidationException exception = assertThrows(
+            ValidationException.class,
+            () -> updateLocationUseCase.execute(1L, request, "testuser")
+        );
+        
+        assertTrue(exception.getMessage().contains("緯度は-90.0～90.0の範囲で指定してください"));
+        verify(locationRepository).findById(1L);
+        verify(locationRepository, never()).save(any());
+    }
+
+    @Test
+    void execute_無効な経度_例外が発生する() {
+        // Arrange
+        UpdateLocationRequest request = new UpdateLocationRequest(
+            35.6892,
+            181.0, // 無効な経度
+            now.plusHours(1)
+        );
+        
+        when(locationRepository.findById(1L)).thenReturn(existingLocation);
+
+        // Act & Assert
+        ValidationException exception = assertThrows(
+            ValidationException.class,
+            () -> updateLocationUseCase.execute(1L, request, "testuser")
+        );
+        
+        assertTrue(exception.getMessage().contains("経度は-180.0～180.0の範囲で指定してください"));
+        verify(locationRepository).findById(1L);
+        verify(locationRepository, never()).save(any());
+    }
+
+    @Test
+    void execute_記録日時がnull_例外が発生する() {
+        // Arrange & Act & Assert
+        // UpdateLocationRequestのコンストラクタでNullPointerExceptionが発生する
+        NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> new UpdateLocationRequest(
+                35.6892,
+                139.6917,
+                null // null記録日時
+            )
+        );
+        
+        assertEquals("記録日時は必須です", exception.getMessage());
+        
+        // リポジトリメソッドは呼ばれない
+        verify(locationRepository, never()).findById(any());
+        verify(locationRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
新機能:
- 位置情報更新API (PUT /api/locations/{id}) 実装
- ページネーション付き検索API (GET /api/locations/search/paged) 実装
- 認証・認可対応（ユーザー別データアクセス制御）

実装コンポーネント:
- UpdateLocationUseCase: 位置情報更新ビジネスロジック
- PageableSearchLocationsUseCase: ページネーション検索機能
- UpdateLocationRequest/PageableSearchLocationsRequest: リクエストDTO
- PagedLocationResponse: ページネーション用レスポンスDTO
- LocationRepository拡張: ページネーション対応メソッド追加
- JPA/InMemoryRepository実装: 全リポジトリ層対応

テスト実装:
- UpdateLocationUseCaseTest: 6テストケース（正常系・異常系）
- PageableSearchLocationsUseCaseTest: 9テストケース完全網羅
- LocationControllerTest: 統合テスト拡張（ページネーション含む）

技術的改善:
- Spring Data Pageableサポート
- バリデーション強化（ページサイズ上限100件）
- 適切な例外ハンドリング（ResourceNotFoundException、AuthorizationException）

残課題をIssue化:
- Issue #20: 地理的範囲検索機能
- Issue #21: 位置情報分析機能
- Issue #22: 統合テスト実装

🤖 Generated with [Claude Code](https://claude.ai/code)