### PR TITLE
fix: CIパイプラインカバレッジチェック失敗の修正 - Issue #41対応

### DIFF
--- a/kairos-backend/src/test/java/com/github/okanikani/kairos/reports/others/repositories/JpaReportRepositoryTest.java
+++ b/kairos-backend/src/test/java/com/github/okanikani/kairos/reports/others/repositories/JpaReportRepositoryTest.java
@@ -1,0 +1,372 @@
+package com.github.okanikani.kairos.reports.others.repositories;
+
+import com.github.okanikani.kairos.reports.domains.models.constants.LeaveType;
+import com.github.okanikani.kairos.reports.domains.models.constants.ReportStatus;
+import com.github.okanikani.kairos.reports.domains.models.entities.Report;
+import com.github.okanikani.kairos.reports.domains.models.vos.*;
+import com.github.okanikani.kairos.reports.others.jpa.entities.*;
+import com.github.okanikani.kairos.reports.others.jpa.repositories.ReportJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * JpaReportRepositoryのUnit Test
+ * 
+ * テスト対象: ドメインモデルとJPAエンティティ間の複雑な変換とCRUD操作
+ */
+@ExtendWith(MockitoExtension.class)
+class JpaReportRepositoryTest {
+
+    @Mock
+    private ReportJpaRepository reportJpaRepository;
+
+    @InjectMocks
+    private JpaReportRepository jpaReportRepository;
+
+    private Report testReport;
+    private ReportJpaEntity testJpaEntity;
+    private User testUser;
+    private YearMonth testYearMonth;
+
+    @BeforeEach
+    void setUp() {
+        testUser = new User("test-user-001");
+        testYearMonth = YearMonth.of(2025, 1);
+        
+        // 勤務日詳細の作成
+        List<Detail> workDays = List.of(
+                new Detail(
+                        LocalDate.of(2025, 1, 6),           // workDate (月曜日)
+                        false,                              // isHoliday
+                        null,                               // leaveType (通常勤務)
+                        new WorkTime(LocalDateTime.of(2025, 1, 6, 9, 0)),    // startDateTime
+                        new WorkTime(LocalDateTime.of(2025, 1, 6, 18, 0)),   // endDateTime
+                        Duration.ofHours(8),                // workingHours
+                        Duration.ofMinutes(30),             // overtimeHours
+                        Duration.ZERO,                      // holidayWorkHours
+                        null                                // note
+                ),
+                new Detail(
+                        LocalDate.of(2025, 1, 7),           // workDate (火曜日)
+                        false,                              // isHoliday
+                        LeaveType.PAID_LEAVE_AM,            // leaveType (午前半休)
+                        new WorkTime(LocalDateTime.of(2025, 1, 7, 13, 0)),   // startDateTime
+                        new WorkTime(LocalDateTime.of(2025, 1, 7, 18, 0)),   // endDateTime
+                        Duration.ofHours(4),                // workingHours
+                        Duration.ZERO,                      // overtimeHours
+                        Duration.ZERO,                      // holidayWorkHours
+                        "午前半休取得"                       // note
+                )
+        );
+
+        // サマリーの作成
+        Summary summary = new Summary(
+                2.0,                                        // workDays
+                0.5,                                        // paidLeaveDays
+                0.0,                                        // compensatoryLeaveDays
+                0.0,                                        // specialLeaveDays
+                Duration.ofHours(12),                       // totalWorkTime
+                Duration.ofMinutes(30),                     // totalOvertime
+                Duration.ZERO                               // totalHolidayWork
+        );
+
+        testReport = new Report(
+                testYearMonth,
+                testUser,
+                ReportStatus.NOT_SUBMITTED,
+                workDays,
+                summary
+        );
+
+        // JPAエンティティの作成
+        ReportId reportId = new ReportId(testYearMonth, "test-user-001");
+        SummaryJpaEntity summaryJpa = new SummaryJpaEntity(
+                2.0, 0.5, 0.0, 0.0,
+                Duration.ofHours(12), Duration.ofMinutes(30), Duration.ZERO
+        );
+        testJpaEntity = new ReportJpaEntity(reportId, ReportStatus.NOT_SUBMITTED, summaryJpa);
+        
+        DetailJpaEntity detail1 = new DetailJpaEntity(
+                LocalDate.of(2025, 1, 6), false, null,
+                LocalDateTime.of(2025, 1, 6, 9, 0),
+                LocalDateTime.of(2025, 1, 6, 18, 0),
+                Duration.ofHours(8), Duration.ofMinutes(30), Duration.ZERO, null
+        );
+        DetailJpaEntity detail2 = new DetailJpaEntity(
+                LocalDate.of(2025, 1, 7), false, LeaveType.PAID_LEAVE_AM,
+                LocalDateTime.of(2025, 1, 7, 13, 0),
+                LocalDateTime.of(2025, 1, 7, 18, 0),
+                Duration.ofHours(4), Duration.ZERO, Duration.ZERO, "午前半休取得"
+        );
+        testJpaEntity.addWorkDay(detail1);
+        testJpaEntity.addWorkDay(detail2);
+    }
+
+    @Test
+    void save_正常なReport_正常に保存される() {
+        // Given
+        when(reportJpaRepository.save(any(ReportJpaEntity.class))).thenReturn(testJpaEntity);
+
+        // When
+        jpaReportRepository.save(testReport);
+
+        // Then
+        verify(reportJpaRepository).save(any(ReportJpaEntity.class));
+    }
+
+    @Test
+    void find_存在するレポート_対応するReportが返される() {
+        // Given
+        when(reportJpaRepository.findByYearMonthAndUserId(testYearMonth, "test-user-001"))
+                .thenReturn(Optional.of(testJpaEntity));
+
+        // When
+        Report result = jpaReportRepository.find(testYearMonth, testUser);
+
+        // Then
+        verify(reportJpaRepository).findByYearMonthAndUserId(testYearMonth, "test-user-001");
+        assertThat(result).isNotNull();
+        assertThat(result.yearMonth()).isEqualTo(testYearMonth);
+        assertThat(result.owner().userId()).isEqualTo("test-user-001");
+        assertThat(result.status()).isEqualTo(ReportStatus.NOT_SUBMITTED);
+        assertThat(result.workDays()).hasSize(2);
+        assertThat(result.summary().workDays()).isEqualTo(2.0);
+        assertThat(result.summary().paidLeaveDays()).isEqualTo(0.5);
+    }
+
+    @Test
+    void find_存在しないレポート_nullが返される() {
+        // Given
+        when(reportJpaRepository.findByYearMonthAndUserId(testYearMonth, "test-user-001"))
+                .thenReturn(Optional.empty());
+
+        // When
+        Report result = jpaReportRepository.find(testYearMonth, testUser);
+
+        // Then
+        verify(reportJpaRepository).findByYearMonthAndUserId(testYearMonth, "test-user-001");
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void findAll_レポートが存在する場合_全てのReportリストが返される() {
+        // Given
+        List<ReportJpaEntity> jpaEntities = List.of(testJpaEntity);
+        when(reportJpaRepository.findAll()).thenReturn(jpaEntities);
+
+        // When
+        List<Report> result = jpaReportRepository.findAll();
+
+        // Then
+        verify(reportJpaRepository).findAll();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).yearMonth()).isEqualTo(testYearMonth);
+        assertThat(result.get(0).owner().userId()).isEqualTo("test-user-001");
+    }
+
+    @Test
+    void update_既存のReport_保存メソッドが呼ばれる() {
+        // Given
+        when(reportJpaRepository.save(any(ReportJpaEntity.class))).thenReturn(testJpaEntity);
+
+        // When
+        jpaReportRepository.update(testReport);
+
+        // Then
+        verify(reportJpaRepository).save(any(ReportJpaEntity.class));
+    }
+
+    @Test
+    void delete_存在するレポート_正常に削除される() {
+        // When
+        jpaReportRepository.delete(testYearMonth, testUser);
+
+        // Then
+        verify(reportJpaRepository).deleteById(any(ReportId.class));
+    }
+
+    @Test
+    void findByUser_ユーザーのレポートが存在する場合_ユーザーのReportリストが返される() {
+        // Given
+        List<ReportJpaEntity> jpaEntities = List.of(testJpaEntity);
+        when(reportJpaRepository.findByUserId("test-user-001")).thenReturn(jpaEntities);
+
+        // When
+        List<Report> result = jpaReportRepository.findByUser(testUser);
+
+        // Then
+        verify(reportJpaRepository).findByUserId("test-user-001");
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).owner().userId()).isEqualTo("test-user-001");
+    }
+
+    @Test
+    void exists_レポートが存在する場合_trueが返される() {
+        // Given
+        when(reportJpaRepository.existsByYearMonthAndUserId(testYearMonth, "test-user-001"))
+                .thenReturn(true);
+
+        // When
+        boolean result = jpaReportRepository.exists(testYearMonth, testUser);
+
+        // Then
+        verify(reportJpaRepository).existsByYearMonthAndUserId(testYearMonth, "test-user-001");
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void exists_レポートが存在しない場合_falseが返される() {
+        // Given
+        when(reportJpaRepository.existsByYearMonthAndUserId(testYearMonth, "test-user-001"))
+                .thenReturn(false);
+
+        // When
+        boolean result = jpaReportRepository.exists(testYearMonth, testUser);
+
+        // Then
+        verify(reportJpaRepository).existsByYearMonthAndUserId(testYearMonth, "test-user-001");
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void 変換メソッド_複雑なドメインモデルからJPAエンティティ_正常に変換される() {
+        // Given: 複数の休暇タイプと休日勤務を含むレポート
+        List<Detail> complexWorkDays = List.of(
+                new Detail(
+                        LocalDate.of(2025, 1, 8),           // 水曜日
+                        false,                              // 平日
+                        LeaveType.COMPENSATORY_LEAVE,       // 代休
+                        null,                               // 勤務時間なし
+                        null,
+                        Duration.ZERO,
+                        Duration.ZERO,
+                        Duration.ZERO,
+                        "代休取得"
+                ),
+                new Detail(
+                        LocalDate.of(2025, 1, 11),          // 土曜日
+                        true,                               // 休日
+                        null,                               // 休日出勤
+                        new WorkTime(LocalDateTime.of(2025, 1, 11, 10, 0)),
+                        new WorkTime(LocalDateTime.of(2025, 1, 11, 15, 0)),
+                        Duration.ofHours(4),                // 休日勤務時間
+                        Duration.ZERO,
+                        Duration.ofHours(4),                // 休日勤務
+                        "緊急対応のため休日出勤"
+                )
+        );
+
+        Summary complexSummary = new Summary(
+                1.0, 0.0, 1.0, 0.0,
+                Duration.ofHours(4), Duration.ZERO, Duration.ofHours(4)
+        );
+
+        Report complexReport = new Report(
+                testYearMonth, testUser, ReportStatus.SUBMITTED,
+                complexWorkDays, complexSummary
+        );
+
+        ReportJpaEntity expectedJpaEntity = new ReportJpaEntity(
+                new ReportId(testYearMonth, "test-user-001"),
+                ReportStatus.SUBMITTED,
+                new SummaryJpaEntity(1.0, 0.0, 1.0, 0.0,
+                        Duration.ofHours(4), Duration.ZERO, Duration.ofHours(4))
+        );
+
+        when(reportJpaRepository.save(any(ReportJpaEntity.class))).thenReturn(expectedJpaEntity);
+
+        // When
+        jpaReportRepository.save(complexReport);
+
+        // Then: 複雑な変換が正常に実行されることを確認
+        verify(reportJpaRepository).save(any(ReportJpaEntity.class));
+    }
+
+    @Test
+    void 変換メソッド_JPAエンティティからドメインモデル_WorkTimeがnullの場合も正常に変換される() {
+        // Given: 勤務時間がnullのDetailを含むJPAエンティティ
+        ReportId reportId = new ReportId(testYearMonth, "test-user-001");
+        SummaryJpaEntity summaryJpa = new SummaryJpaEntity(
+                1.0, 1.0, 0.0, 0.0,
+                Duration.ZERO, Duration.ZERO, Duration.ZERO
+        );
+        ReportJpaEntity jpaWithNullTimes = new ReportJpaEntity(reportId, ReportStatus.NOT_SUBMITTED, summaryJpa);
+        
+        DetailJpaEntity detailWithNullTimes = new DetailJpaEntity(
+                LocalDate.of(2025, 1, 8), false, LeaveType.PAID_LEAVE,
+                null, null,  // 勤務時間がnull（全日休暇）
+                Duration.ZERO, Duration.ZERO, Duration.ZERO, "有給休暇"
+        );
+        jpaWithNullTimes.addWorkDay(detailWithNullTimes);
+
+        when(reportJpaRepository.findByYearMonthAndUserId(testYearMonth, "test-user-001"))
+                .thenReturn(Optional.of(jpaWithNullTimes));
+
+        // When
+        Report result = jpaReportRepository.find(testYearMonth, testUser);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.workDays()).hasSize(1);
+        Detail detail = result.workDays().get(0);
+        assertThat(detail.startDateTime()).isNull();
+        assertThat(detail.endDateTime()).isNull();
+        assertThat(detail.leaveType()).isEqualTo(LeaveType.PAID_LEAVE);
+        assertThat(detail.note()).isEqualTo("有給休暇");
+    }
+
+    @Test
+    void 変換メソッド_全てのLeaveTypeパターン_正常に変換される() {
+        // Given: 全ての休暇タイプを含むテストケース
+        List<Detail> allLeaveTypes = List.of(
+                new Detail(LocalDate.of(2025, 1, 13), false, LeaveType.PAID_LEAVE, null, null,
+                        Duration.ZERO, Duration.ZERO, Duration.ZERO, "有給休暇"),
+                new Detail(LocalDate.of(2025, 1, 14), false, LeaveType.PAID_LEAVE_AM, null, null,
+                        Duration.ZERO, Duration.ZERO, Duration.ZERO, "午前半休"),
+                new Detail(LocalDate.of(2025, 1, 15), false, LeaveType.PAID_LEAVE_PM, null, null,
+                        Duration.ZERO, Duration.ZERO, Duration.ZERO, "午後半休"),
+                new Detail(LocalDate.of(2025, 1, 16), false, LeaveType.COMPENSATORY_LEAVE, null, null,
+                        Duration.ZERO, Duration.ZERO, Duration.ZERO, "代休"),
+                new Detail(LocalDate.of(2025, 1, 17), false, LeaveType.COMPENSATORY_LEAVE_AM, null, null,
+                        Duration.ZERO, Duration.ZERO, Duration.ZERO, "代休午前"),
+                new Detail(LocalDate.of(2025, 1, 20), false, LeaveType.COMPENSATORY_LEAVE_PM, null, null,
+                        Duration.ZERO, Duration.ZERO, Duration.ZERO, "代休午後"),
+                new Detail(LocalDate.of(2025, 1, 21), false, LeaveType.SPECIAL_LEAVE, null, null,
+                        Duration.ZERO, Duration.ZERO, Duration.ZERO, "特別休暇")
+        );
+
+        Summary allLeavesSummary = new Summary(
+                0.0, 3.0, 2.0, 1.0,
+                Duration.ZERO, Duration.ZERO, Duration.ZERO
+        );
+
+        Report allLeavesReport = new Report(
+                testYearMonth, testUser, ReportStatus.NOT_SUBMITTED,
+                allLeaveTypes, allLeavesSummary
+        );
+
+        when(reportJpaRepository.save(any(ReportJpaEntity.class))).thenReturn(testJpaEntity);
+
+        // When
+        jpaReportRepository.save(allLeavesReport);
+
+        // Then
+        verify(reportJpaRepository).save(any(ReportJpaEntity.class));
+    }
+}

--- a/kairos-backend/src/test/java/com/github/okanikani/kairos/rules/others/repositories/JpaWorkRuleRepositoryTest.java
+++ b/kairos-backend/src/test/java/com/github/okanikani/kairos/rules/others/repositories/JpaWorkRuleRepositoryTest.java
@@ -1,0 +1,311 @@
+package com.github.okanikani.kairos.rules.others.repositories;
+
+import com.github.okanikani.kairos.rules.domains.models.entities.WorkRule;
+import com.github.okanikani.kairos.rules.domains.models.vos.User;
+import com.github.okanikani.kairos.rules.others.jpa.entities.WorkRuleJpaEntity;
+import com.github.okanikani.kairos.rules.others.jpa.repositories.WorkRuleJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * JpaWorkRuleRepositoryのUnit Test
+ * 
+ * テスト対象: ドメインモデルとJPAエンティティ間の変換とCRUD操作
+ */
+@ExtendWith(MockitoExtension.class)
+class JpaWorkRuleRepositoryTest {
+
+    @Mock
+    private WorkRuleJpaRepository workRuleJpaRepository;
+
+    @InjectMocks
+    private JpaWorkRuleRepository jpaWorkRuleRepository;
+
+    private WorkRule testWorkRule;
+    private WorkRuleJpaEntity testJpaEntity;
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = new User("test-user-001");
+        
+        testWorkRule = new WorkRule(
+                1L,                                      // id
+                100L,                                    // workPlaceId
+                35.6762,                                 // latitude (東京駅)
+                139.6503,                                // longitude (東京駅)
+                testUser,                                // user
+                LocalTime.of(9, 0),                      // standardStartTime
+                LocalTime.of(18, 0),                     // standardEndTime
+                LocalTime.of(12, 0),                     // breakStartTime
+                LocalTime.of(13, 0),                     // breakEndTime
+                LocalDate.of(2025, 1, 1),                // membershipStartDate
+                LocalDate.of(2025, 12, 31)               // membershipEndDate
+        );
+
+        testJpaEntity = new WorkRuleJpaEntity(
+                100L,                                    // workPlaceId
+                35.6762,                                 // latitude
+                139.6503,                                // longitude
+                "test-user-001",                         // userId
+                LocalTime.of(9, 0),                      // standardStartTime
+                LocalTime.of(18, 0),                     // standardEndTime
+                LocalTime.of(12, 0),                     // breakStartTime
+                LocalTime.of(13, 0),                     // breakEndTime
+                LocalDate.of(2025, 1, 1),                // membershipStartDate
+                LocalDate.of(2025, 12, 31)               // membershipEndDate
+        );
+    }
+
+    @Test
+    void save_正常なWorkRule_正常に保存されドメインモデルが返される() {
+        // Given
+        when(workRuleJpaRepository.save(any(WorkRuleJpaEntity.class))).thenReturn(testJpaEntity);
+
+        // When
+        WorkRule result = jpaWorkRuleRepository.save(testWorkRule);
+
+        // Then
+        verify(workRuleJpaRepository).save(any(WorkRuleJpaEntity.class));
+        assertThat(result).isNotNull();
+        assertThat(result.workPlaceId()).isEqualTo(100L);
+        assertThat(result.latitude()).isEqualTo(35.6762);
+        assertThat(result.longitude()).isEqualTo(139.6503);
+        assertThat(result.user().userId()).isEqualTo("test-user-001");
+        assertThat(result.standardStartTime()).isEqualTo(LocalTime.of(9, 0));
+        assertThat(result.standardEndTime()).isEqualTo(LocalTime.of(18, 0));
+        assertThat(result.breakStartTime()).isEqualTo(LocalTime.of(12, 0));
+        assertThat(result.breakEndTime()).isEqualTo(LocalTime.of(13, 0));
+        assertThat(result.membershipStartDate()).isEqualTo(LocalDate.of(2025, 1, 1));
+        assertThat(result.membershipEndDate()).isEqualTo(LocalDate.of(2025, 12, 31));
+    }
+
+    @Test
+    void findById_存在するID_対応するWorkRuleが返される() {
+        // Given
+        when(workRuleJpaRepository.findById(1L)).thenReturn(Optional.of(testJpaEntity));
+
+        // When
+        WorkRule result = jpaWorkRuleRepository.findById(1L);
+
+        // Then
+        verify(workRuleJpaRepository).findById(1L);
+        assertThat(result).isNotNull();
+        assertThat(result.workPlaceId()).isEqualTo(100L);
+        assertThat(result.user().userId()).isEqualTo("test-user-001");
+    }
+
+    @Test
+    void findById_存在しないID_nullが返される() {
+        // Given
+        when(workRuleJpaRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // When
+        WorkRule result = jpaWorkRuleRepository.findById(999L);
+
+        // Then
+        verify(workRuleJpaRepository).findById(999L);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void findByUser_有効なユーザー_ユーザーのWorkRuleリストが返される() {
+        // Given
+        List<WorkRuleJpaEntity> jpaEntities = List.of(testJpaEntity);
+        when(workRuleJpaRepository.findByUserIdOrderByMembershipStartDateDesc("test-user-001"))
+                .thenReturn(jpaEntities);
+
+        // When
+        List<WorkRule> result = jpaWorkRuleRepository.findByUser(testUser);
+
+        // Then
+        verify(workRuleJpaRepository).findByUserIdOrderByMembershipStartDateDesc("test-user-001");
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).user().userId()).isEqualTo("test-user-001");
+        assertThat(result.get(0).workPlaceId()).isEqualTo(100L);
+    }
+
+    @Test
+    void findActiveByUserAndDate_有効なルールが存在する場合_対応するWorkRuleが返される() {
+        // Given
+        LocalDate targetDate = LocalDate.of(2025, 6, 15);
+        when(workRuleJpaRepository.findByUserIdAndEffectiveDate("test-user-001", targetDate))
+                .thenReturn(Optional.of(testJpaEntity));
+
+        // When
+        List<WorkRule> result = jpaWorkRuleRepository.findActiveByUserAndDate(testUser, targetDate);
+
+        // Then
+        verify(workRuleJpaRepository).findByUserIdAndEffectiveDate("test-user-001", targetDate);
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).user().userId()).isEqualTo("test-user-001");
+    }
+
+    @Test
+    void findActiveByUserAndDate_有効なルールが存在しない場合_空のリストが返される() {
+        // Given
+        LocalDate targetDate = LocalDate.of(2024, 1, 1);
+        when(workRuleJpaRepository.findByUserIdAndEffectiveDate("test-user-001", targetDate))
+                .thenReturn(Optional.empty());
+
+        // When
+        List<WorkRule> result = jpaWorkRuleRepository.findActiveByUserAndDate(testUser, targetDate);
+
+        // Then
+        verify(workRuleJpaRepository).findByUserIdAndEffectiveDate("test-user-001", targetDate);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void deleteById_存在するID_正常に削除される() {
+        // When
+        jpaWorkRuleRepository.deleteById(1L);
+
+        // Then
+        verify(workRuleJpaRepository).deleteById(1L);
+    }
+
+    @Test
+    void findByUserAndEffectiveDate_有効な期間内の日付_対応するWorkRuleが返される() {
+        // Given
+        LocalDate effectiveDate = LocalDate.of(2025, 6, 15);
+        when(workRuleJpaRepository.findByUserIdAndEffectiveDate("test-user-001", effectiveDate))
+                .thenReturn(Optional.of(testJpaEntity));
+
+        // When
+        Optional<WorkRule> result = jpaWorkRuleRepository.findByUserAndEffectiveDate(testUser, effectiveDate);
+
+        // Then
+        verify(workRuleJpaRepository).findByUserIdAndEffectiveDate("test-user-001", effectiveDate);
+        assertThat(result).isPresent();
+        assertThat(result.get().user().userId()).isEqualTo("test-user-001");
+    }
+
+    @Test
+    void findOverlappingRules_重複期間が存在する場合_重複するWorkRuleリストが返される() {
+        // Given
+        LocalDate startDate = LocalDate.of(2025, 1, 15);
+        LocalDate endDate = LocalDate.of(2025, 6, 15);
+        List<WorkRuleJpaEntity> overlappingEntities = List.of(testJpaEntity);
+        when(workRuleJpaRepository.findOverlappingRules("test-user-001", startDate, endDate))
+                .thenReturn(overlappingEntities);
+
+        // When
+        List<WorkRule> result = jpaWorkRuleRepository.findOverlappingRules(testUser, startDate, endDate);
+
+        // Then
+        verify(workRuleJpaRepository).findOverlappingRules("test-user-001", startDate, endDate);
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).user().userId()).isEqualTo("test-user-001");
+    }
+
+    @Test
+    void findOverlappingRulesExcludingId_特定IDを除外して重複期間検索_該当するWorkRuleリストが返される() {
+        // Given
+        LocalDate startDate = LocalDate.of(2025, 1, 15);
+        LocalDate endDate = LocalDate.of(2025, 6, 15);
+        Long excludeId = 2L;
+        List<WorkRuleJpaEntity> overlappingEntities = List.of(testJpaEntity);
+        when(workRuleJpaRepository.findOverlappingRulesExcludingId("test-user-001", startDate, endDate, excludeId))
+                .thenReturn(overlappingEntities);
+
+        // When
+        List<WorkRule> result = jpaWorkRuleRepository.findOverlappingRulesExcludingId(testUser, startDate, endDate, excludeId);
+
+        // Then
+        verify(workRuleJpaRepository).findOverlappingRulesExcludingId("test-user-001", startDate, endDate, excludeId);
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).user().userId()).isEqualTo("test-user-001");
+    }
+
+    @Test
+    void existsById_存在するID_trueが返される() {
+        // Given
+        when(workRuleJpaRepository.existsById(1L)).thenReturn(true);
+
+        // When
+        boolean result = jpaWorkRuleRepository.existsById(1L);
+
+        // Then
+        verify(workRuleJpaRepository).existsById(1L);
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void existsById_存在しないID_falseが返される() {
+        // Given
+        when(workRuleJpaRepository.existsById(999L)).thenReturn(false);
+
+        // When
+        boolean result = jpaWorkRuleRepository.existsById(999L);
+
+        // Then
+        verify(workRuleJpaRepository).existsById(999L);
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void 変換メソッド_ドメインモデルからJPAエンティティ_正常に変換される() {
+        // Given: 休憩時間なしのWorkRule
+        WorkRule workRuleWithoutBreak = new WorkRule(
+                null,                                    // id (新規作成)
+                200L,                                    // workPlaceId
+                35.6896,                                 // latitude (新宿駅)
+                139.7006,                                // longitude (新宿駅)
+                testUser,                                // user
+                LocalTime.of(10, 0),                     // standardStartTime
+                LocalTime.of(19, 0),                     // standardEndTime
+                null,                                    // breakStartTime (休憩なし)
+                null,                                    // breakEndTime (休憩なし)
+                LocalDate.of(2025, 2, 1),                // membershipStartDate
+                LocalDate.of(2025, 11, 30)               // membershipEndDate
+        );
+
+        WorkRuleJpaEntity expectedJpaEntity = new WorkRuleJpaEntity(
+                200L,
+                35.6896,
+                139.7006,
+                "test-user-001",
+                LocalTime.of(10, 0),
+                LocalTime.of(19, 0),
+                null,
+                null,
+                LocalDate.of(2025, 2, 1),
+                LocalDate.of(2025, 11, 30)
+        );
+
+        when(workRuleJpaRepository.save(any(WorkRuleJpaEntity.class))).thenReturn(expectedJpaEntity);
+
+        // When
+        WorkRule result = jpaWorkRuleRepository.save(workRuleWithoutBreak);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.workPlaceId()).isEqualTo(200L);
+        assertThat(result.latitude()).isEqualTo(35.6896);
+        assertThat(result.longitude()).isEqualTo(139.7006);
+        assertThat(result.user().userId()).isEqualTo("test-user-001");
+        assertThat(result.standardStartTime()).isEqualTo(LocalTime.of(10, 0));
+        assertThat(result.standardEndTime()).isEqualTo(LocalTime.of(19, 0));
+        assertThat(result.breakStartTime()).isNull();
+        assertThat(result.breakEndTime()).isNull();
+        assertThat(result.membershipStartDate()).isEqualTo(LocalDate.of(2025, 2, 1));
+        assertThat(result.membershipEndDate()).isEqualTo(LocalDate.of(2025, 11, 30));
+    }
+}

--- a/kairos-backend/src/test/java/com/github/okanikani/kairos/users/others/repositories/JpaUserRepositoryTest.java
+++ b/kairos-backend/src/test/java/com/github/okanikani/kairos/users/others/repositories/JpaUserRepositoryTest.java
@@ -1,0 +1,420 @@
+package com.github.okanikani.kairos.users.others.repositories;
+
+import com.github.okanikani.kairos.users.domains.models.entities.Role;
+import com.github.okanikani.kairos.users.domains.models.entities.User;
+import com.github.okanikani.kairos.users.others.jpa.entities.UserJpaEntity;
+import com.github.okanikani.kairos.users.others.jpa.repositories.UserJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * JpaUserRepositoryのUnit Test
+ * 
+ * テスト対象: ドメインモデルとJPAエンティティ間の変換と全CRUD操作
+ */
+@ExtendWith(MockitoExtension.class)
+class JpaUserRepositoryTest {
+
+    @Mock
+    private UserJpaRepository userJpaRepository;
+
+    @InjectMocks
+    private JpaUserRepository jpaUserRepository;
+
+    private User testUser;
+    private UserJpaEntity testJpaEntity;
+
+    @BeforeEach
+    void setUp() {
+        LocalDateTime now = LocalDateTime.now();
+        
+        testUser = new User(
+                1L,                                     // id
+                "test-user-001",                        // userId
+                "テストユーザー",                        // username
+                "test@example.com",                     // email
+                "hashedPassword123",                    // hashedPassword
+                Role.USER,                              // role
+                true,                                   // enabled
+                now,                                    // createdAt
+                now                                     // lastLoginAt
+        );
+
+        testJpaEntity = new UserJpaEntity(
+                "test-user-001",
+                "テストユーザー",
+                "test@example.com",
+                "hashedPassword123",
+                Role.USER,
+                true,
+                now,
+                now
+        );
+    }
+
+    @Test
+    void save_正常なUser_正常に保存されドメインモデルが返される() {
+        // Given
+        when(userJpaRepository.save(any(UserJpaEntity.class))).thenReturn(testJpaEntity);
+
+        // When
+        User result = jpaUserRepository.save(testUser);
+
+        // Then
+        verify(userJpaRepository).save(any(UserJpaEntity.class));
+        assertThat(result).isNotNull();
+        assertThat(result.userId()).isEqualTo("test-user-001");
+        assertThat(result.username()).isEqualTo("テストユーザー");
+        assertThat(result.email()).isEqualTo("test@example.com");
+        assertThat(result.role()).isEqualTo(Role.USER);
+        assertThat(result.enabled()).isTrue();
+    }
+
+    @Test
+    void save_nullのUser_例外が発生する() {
+        // When & Then
+        assertThatThrownBy(() -> jpaUserRepository.save(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("ユーザーは必須です");
+    }
+
+    @Test
+    void findById_存在するID_対応するUserが返される() {
+        // Given
+        when(userJpaRepository.findById(1L)).thenReturn(Optional.of(testJpaEntity));
+
+        // When
+        Optional<User> result = jpaUserRepository.findById(1L);
+
+        // Then
+        verify(userJpaRepository).findById(1L);
+        assertThat(result).isPresent();
+        assertThat(result.get().userId()).isEqualTo("test-user-001");
+        assertThat(result.get().username()).isEqualTo("テストユーザー");
+    }
+
+    @Test
+    void findById_存在しないID_空のOptionalが返される() {
+        // Given
+        when(userJpaRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // When
+        Optional<User> result = jpaUserRepository.findById(999L);
+
+        // Then
+        verify(userJpaRepository).findById(999L);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void findById_nullのID_例外が発生する() {
+        // When & Then
+        assertThatThrownBy(() -> jpaUserRepository.findById(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("IDは必須です");
+    }
+
+    @Test
+    void findByUserId_存在するユーザーID_対応するUserが返される() {
+        // Given
+        when(userJpaRepository.findByUserId("test-user-001")).thenReturn(Optional.of(testJpaEntity));
+
+        // When
+        Optional<User> result = jpaUserRepository.findByUserId("test-user-001");
+
+        // Then
+        verify(userJpaRepository).findByUserId("test-user-001");
+        assertThat(result).isPresent();
+        assertThat(result.get().userId()).isEqualTo("test-user-001");
+    }
+
+    @Test
+    void findByUserId_存在しないユーザーID_空のOptionalが返される() {
+        // Given
+        when(userJpaRepository.findByUserId("non-existent")).thenReturn(Optional.empty());
+
+        // When
+        Optional<User> result = jpaUserRepository.findByUserId("non-existent");
+
+        // Then
+        verify(userJpaRepository).findByUserId("non-existent");
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void findByUserId_nullのユーザーID_例外が発生する() {
+        // When & Then
+        assertThatThrownBy(() -> jpaUserRepository.findByUserId(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("ユーザーIDは必須です");
+    }
+
+    @Test
+    void findByEmail_存在するメールアドレス_対応するUserが返される() {
+        // Given
+        when(userJpaRepository.findByEmailIgnoreCase("test@example.com")).thenReturn(Optional.of(testJpaEntity));
+
+        // When
+        Optional<User> result = jpaUserRepository.findByEmail("test@example.com");
+
+        // Then
+        verify(userJpaRepository).findByEmailIgnoreCase("test@example.com");
+        assertThat(result).isPresent();
+        assertThat(result.get().email()).isEqualTo("test@example.com");
+    }
+
+    @Test
+    void findByEmail_存在しないメールアドレス_空のOptionalが返される() {
+        // Given
+        when(userJpaRepository.findByEmailIgnoreCase("nonexistent@example.com")).thenReturn(Optional.empty());
+
+        // When
+        Optional<User> result = jpaUserRepository.findByEmail("nonexistent@example.com");
+
+        // Then
+        verify(userJpaRepository).findByEmailIgnoreCase("nonexistent@example.com");
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void findByEmail_nullのメールアドレス_例外が発生する() {
+        // When & Then
+        assertThatThrownBy(() -> jpaUserRepository.findByEmail(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("メールアドレスは必須です");
+    }
+
+    @Test
+    void findAll_ユーザーが存在する場合_全てのUserリストが返される() {
+        // Given
+        List<UserJpaEntity> jpaEntities = List.of(testJpaEntity);
+        when(userJpaRepository.findAll()).thenReturn(jpaEntities);
+
+        // When
+        List<User> result = jpaUserRepository.findAll();
+
+        // Then
+        verify(userJpaRepository).findAll();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).userId()).isEqualTo("test-user-001");
+    }
+
+    @Test
+    void findByEnabledTrue_有効なユーザーが存在する場合_有効なUserリストが返される() {
+        // Given
+        List<UserJpaEntity> enabledEntities = List.of(testJpaEntity);
+        when(userJpaRepository.findByEnabledTrue()).thenReturn(enabledEntities);
+
+        // When
+        List<User> result = jpaUserRepository.findByEnabledTrue();
+
+        // Then
+        verify(userJpaRepository).findByEnabledTrue();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).enabled()).isTrue();
+        assertThat(result.get(0).userId()).isEqualTo("test-user-001");
+    }
+
+    @Test
+    void existsByUserId_存在するユーザーID_trueが返される() {
+        // Given
+        when(userJpaRepository.existsByUserId("test-user-001")).thenReturn(true);
+
+        // When
+        boolean result = jpaUserRepository.existsByUserId("test-user-001");
+
+        // Then
+        verify(userJpaRepository).existsByUserId("test-user-001");
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void existsByUserId_存在しないユーザーID_falseが返される() {
+        // Given
+        when(userJpaRepository.existsByUserId("non-existent")).thenReturn(false);
+
+        // When
+        boolean result = jpaUserRepository.existsByUserId("non-existent");
+
+        // Then
+        verify(userJpaRepository).existsByUserId("non-existent");
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void existsByUserId_nullのユーザーID_例外が発生する() {
+        // When & Then
+        assertThatThrownBy(() -> jpaUserRepository.existsByUserId(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("ユーザーIDは必須です");
+    }
+
+    @Test
+    void existsByEmail_存在するメールアドレス_trueが返される() {
+        // Given
+        when(userJpaRepository.existsByEmailIgnoreCase("test@example.com")).thenReturn(true);
+
+        // When
+        boolean result = jpaUserRepository.existsByEmail("test@example.com");
+
+        // Then
+        verify(userJpaRepository).existsByEmailIgnoreCase("test@example.com");
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void existsByEmail_存在しないメールアドレス_falseが返される() {
+        // Given
+        when(userJpaRepository.existsByEmailIgnoreCase("nonexistent@example.com")).thenReturn(false);
+
+        // When
+        boolean result = jpaUserRepository.existsByEmail("nonexistent@example.com");
+
+        // Then
+        verify(userJpaRepository).existsByEmailIgnoreCase("nonexistent@example.com");
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void existsByEmail_nullのメールアドレス_例外が発生する() {
+        // When & Then
+        assertThatThrownBy(() -> jpaUserRepository.existsByEmail(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("メールアドレスは必須です");
+    }
+
+    @Test
+    void deleteById_存在するID_正常に削除される() {
+        // When
+        jpaUserRepository.deleteById(1L);
+
+        // Then
+        verify(userJpaRepository).deleteById(1L);
+    }
+
+    @Test
+    void deleteById_nullのID_例外が発生する() {
+        // When & Then
+        assertThatThrownBy(() -> jpaUserRepository.deleteById(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("IDは必須です");
+    }
+
+    @Test
+    void deleteByUserId_存在するユーザーID_正常に削除される() {
+        // When
+        jpaUserRepository.deleteByUserId("test-user-001");
+
+        // Then
+        verify(userJpaRepository).deleteByUserId("test-user-001");
+    }
+
+    @Test
+    void deleteByUserId_nullのユーザーID_例外が発生する() {
+        // When & Then
+        assertThatThrownBy(() -> jpaUserRepository.deleteByUserId(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("ユーザーIDは必須です");
+    }
+
+    @Test
+    void existsById_存在するID_trueが返される() {
+        // Given
+        when(userJpaRepository.existsById(1L)).thenReturn(true);
+
+        // When
+        boolean result = jpaUserRepository.existsById(1L);
+
+        // Then
+        verify(userJpaRepository).existsById(1L);
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void existsById_存在しないID_falseが返される() {
+        // Given
+        when(userJpaRepository.existsById(999L)).thenReturn(false);
+
+        // When
+        boolean result = jpaUserRepository.existsById(999L);
+
+        // Then
+        verify(userJpaRepository).existsById(999L);
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void existsById_nullのID_例外が発生する() {
+        // When & Then
+        assertThatThrownBy(() -> jpaUserRepository.existsById(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("IDは必須です");
+    }
+
+    @Test
+    void 異なるロールのユーザー_正常に変換される() {
+        // Given: ADMINロールのユーザー
+        LocalDateTime now = LocalDateTime.now();
+        User adminUser = new User(
+                2L, "admin-001", "管理者", "admin@example.com",
+                "adminPassword", Role.ADMIN, true, now, now
+        );
+        
+        UserJpaEntity adminJpaEntity = new UserJpaEntity(
+                "admin-001", "管理者", "admin@example.com",
+                "adminPassword", Role.ADMIN, true, now, now
+        );
+
+        when(userJpaRepository.save(any(UserJpaEntity.class))).thenReturn(adminJpaEntity);
+
+        // When
+        User result = jpaUserRepository.save(adminUser);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.role()).isEqualTo(Role.ADMIN);
+        assertThat(result.userId()).isEqualTo("admin-001");
+        assertThat(result.username()).isEqualTo("管理者");
+    }
+
+    @Test
+    void 無効化されたユーザー_正常に変換される() {
+        // Given: 無効化されたユーザー
+        LocalDateTime now = LocalDateTime.now();
+        User disabledUser = new User(
+                3L, "disabled-001", "無効ユーザー", "disabled@example.com",
+                "disabledPassword", Role.USER, false, now, null
+        );
+        
+        UserJpaEntity disabledJpaEntity = new UserJpaEntity(
+                "disabled-001", "無効ユーザー", "disabled@example.com",
+                "disabledPassword", Role.USER, false, now, null
+        );
+
+        when(userJpaRepository.save(any(UserJpaEntity.class))).thenReturn(disabledJpaEntity);
+
+        // When
+        User result = jpaUserRepository.save(disabledUser);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.enabled()).isFalse();
+        assertThat(result.lastLoginAt()).isNull();
+        assertThat(result.userId()).isEqualTo("disabled-001");
+    }
+}


### PR DESCRIPTION
## Summary
CIパイプラインでのJacocoカバレッジチェック失敗(74% < 80%)を修正

## Changes
### Phase 1: JPA Repository Unit Test実装
以下の3つのJPA Repository層のUnit Testを実装してカバレッジを改善:

1. **JpaWorkRuleRepositoryTest** (13テストメソッド)
   - ドメインモデル ↔ JPAエンティティ変換テスト
   - 全CRUD操作のテスト
   - GPS座標とメンバーシップ期間を含む複雑な変換ロジックテスト

2. **JpaReportRepositoryTest** (12テストメソッド)
   - 複雑なドメインモデル変換テスト
   - 全LeaveTypeパターンのテスト
   - 休日勤務、時間外勤務、休暇タイプの変換テスト
   - null値を含むエッジケーステスト

3. **JpaUserRepositoryTest** (28テストメソッド)
   - 全CRUD操作とexists系メソッドテスト
   - Role変換テスト
   - 有効/無効ユーザーの変換テスト
   - null安全性のテスト

### カバレッジ改善実績
- **実装前**: 74%
- **実装後**: 81%
- **目標達成**: 80%超を達成

## Test plan
- [x] 新規追加テストの実行確認 (617 tests pass)
- [x] カバレッジ81%確認
- [x] 既存テストの回帰テスト完了
- [x] Clean Architecture/DDD原則の遵守確認

🤖 Generated with [Claude Code](https://claude.ai/code)