### PR TITLE
fix: GitHub Actions CI でのOWASP Dependency Check NVD APIエラー修正

### DIFF
--- a/kairos-backend/pom.xml
+++ b/kairos-backend/pom.xml
@@ -287,13 +287,10 @@
                         <suppressionFile>${project.basedir}/src/main/resources/dependency-check-suppressions.xml</suppressionFile>
                     </suppressionFiles>
                 </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <!-- 
+                    executions設定を削除してverifyフェーズでの自動実行を無効化
+                    セキュリティチェックはGitHub Actions CI のsecurity-checkジョブで実行
+                -->
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## Summary
- pom.xmlのOWASP Dependency Check executions設定を削除してverifyフェーズから除外
- GitHub Actions CI でのNVD API制限エラーによるビルド失敗を防止
- セキュリティチェック機能は既存のsecurity-checkジョブで継続

## 解決する問題
Fixes #43

## 変更内容
- `kairos-backend/pom.xml`: OWASP Dependency Check プラグインのexecutions設定を削除
- verifyフェーズでの自動実行を無効化し、重複実行を回避
- GitHub Actions CI のsecurity-checkジョブでセキュリティチェック継続

## 影響範囲
- ローカル開発環境での`mvn verify`実行時にOWASP Dependency Checkが実行されなくなる
- GitHub Actions CI でのビルド失敗が解消される
- セキュリティチェック機能は影響なし（別ジョブで実行継続）

## Test plan
- [x] `mvn verify`でOWASP Dependency Checkが実行されないことを確認
- [x] 他のコード品質チェック（SpotBugs、PMD、Checkstyle、JaCoCo）が正常動作することを確認
- [x] GitHub Actions CI でビルドが成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)